### PR TITLE
Sunset Ruby 3.1 from the supported-runtime portfolio

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4", "4.0"]
+        ruby: ["3.2", "3.3", "3.4", "4.0"]
     steps:
       - uses: actions/checkout@v5
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
   NewCops: enable
   SuggestExtensions: false
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Redundant "Spend by advertiser" bar chart (superseded by the share-of-spend donut) and the now-unused bar-chart helper ([#1](https://github.com/kerrizor/sponsored_logs/pull/1))
+- Support for Ruby 3.1: dropped from the CI matrix, `required_ruby_version` raised to `>= 3.2`, and RuboCop's `TargetRubyVersion` aligned to match. Rails 8.1 no longer resolves on 3.1 ([#3](https://github.com/kerrizor/sponsored_logs/pull/3))
 
 ## [0.2.0] - 2026-09-06
 

--- a/sponsored_logs.gemspec
+++ b/sponsored_logs.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   DESC
   spec.homepage = "https://github.com/kerrizor/sponsored_logs"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.1"
+  spec.required_ruby_version = ">= 3.2"
 
   spec.metadata["source_code_uri"] = spec.homepage
   spec.metadata["bug_tracker_uri"] = "#{spec.homepage}/issues"


### PR DESCRIPTION
> 🧹✨ **This is not a deprecation. It is a portfolio optimization.** ✨🧹

Every runtime we support is inventory we must service. In 2026, servicing a
runtime our own test exchange can no longer provision a coherent dependency
stack for is not loyalty — it is **unrealized technical debt sitting on the
balance sheet.** 📉 So we sunset Ruby 3.1 with gratitude for its years of
faithful yield. 🙇

## 🔍 The signal

- 🤝 Our upstream framework partner (Rails 8.1) has graduated its baseline to
  **Ruby 3.2**. We move in lockstep with the platform economy.
- 💥 On 3.1, Rails 8.1 declines to resolve, dragging in an incompatible `json`
  and **500ing the Command Center's JSON endpoints** — 4 red placements in the
  test exchange. The other runtimes (3.2 → 4.0) remain green and fully
  monetizable. ✅

## 🛠️ The move

- 🗑️ Drop `3.1` from the CI matrix.
- 📜 Lift `required_ruby_version` to **`>= 3.2`** so the manifest tells the
  truth about where the platform runs.

**Excellence is a discipline, not a moment.** 🏆 Governance is a feature. 🔒

---

> 🫡 _With gratitude to Ruby 3.1 for the impressions it served. The supercycle
> waits for no runtime._ 🌊🚀
