### PR TITLE
Recover suppressed inventory on the storefront demo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Marketing site: sponsor placements in the demo terminal are now delivered reliably. Renamed inventory-bearing CSS classes so client-side ad blockers can no longer suppress the platform's own impressions, and corrected the log-line layout so each placement occupies its own row ([#4](https://github.com/sponsoredlogs/sponsored_logs/pull/4))
+
 ### Added
 
 - Per-ad `advertiser` field so creatives roll up to an advertiser account; defaults to `"Unattributed"` when omitted, and the built-in ads carry real brand names ([#1](https://github.com/kerrizor/sponsored_logs/pull/1))

--- a/docs/index.html
+++ b/docs/index.html
@@ -169,15 +169,14 @@
       overflow-x: auto;
       line-height: 1.7;
     }
-    .term-body .line { white-space: pre; color: var(--muted); }
+    .term-body .line { display: block; white-space: pre-wrap; color: var(--muted); }
     .term-body .ts { color: var(--faint); }
     .term-body .info { color: #60a5fa; }
     .term-body .err { color: var(--red); }
-    .ad-line {
-      display: inline-block;
+    .yield-line {
       color: var(--gold-2);
     }
-    .ad-tag {
+    .yield-tag {
       background: linear-gradient(90deg, var(--gold) 0%, var(--gold-2) 100%);
       color: #000;
       font-weight: 900;
@@ -341,9 +340,9 @@
       <div class="term-body">
 <span class="line"><span class="ts">[14:22:07]</span> <span class="info">INFO</span>  Processing checkout for order #48213</span>
 <span class="line"><span class="ts">[14:22:07]</span> <span class="info">INFO</span>  PaymentGateway: authorized $129.00</span>
-<span class="line"><span class="ad-tag">AD</span><span class="ad-line">Brought to you by Contoso — the enterprise you invented for the demo.</span></span>
+<span class="line"><span class="yield-tag">AD</span><span class="yield-line">Brought to you by Contoso — the enterprise you invented for the demo.</span></span>
 <span class="line"><span class="ts">[14:22:08]</span> <span class="err">ERROR</span> ActiveRecord::ConnectionTimeout (high-intent placement)</span>
-<span class="line"><span class="ad-tag">AD</span><span class="ad-line">Initech. We put the TPS in your reports.</span></span>
+<span class="line"><span class="yield-tag">AD</span><span class="yield-line">Initech. We put the TPS in your reports.</span></span>
 <span class="line"><span class="ts">[14:22:09]</span> <span class="info">INFO</span>  Retry succeeded, connection restored</span>
       </div>
     </div>


### PR DESCRIPTION
> 🚫💰 **An ad platform was blocked by an ad blocker.** We do not say this lightly. 💰🚫

The Command Center's live-inventory demo — the single most important
above-the-fold proof of the thesis — was silently leaking impressions. 😱
Client-side ad blockers were matching our placement CSS classes (`ad-tag`,
`ad-line`) and suppressing the very inventory that demonstrates the platform.
**100% viewability, 0% delivery.** Unacceptable.

## 🛠️ The recovery

- 🏷️ **Renamed the inventory-bearing classes** — `ad-tag` → `yield-tag`,
  `ad-line` → `yield-line` — so blocklists no longer recognize our premium
  placements. Fill rate restored to 100%. 📈
- 📐 **Corrected the log-line layout** — each line is now its own block, so
  placements and telemetry no longer collapse into a single run-on line. Every
  impression gets the real estate its CPM paid for. 💸

## ✅ Diligence

- 🎨 CSS-only change to `docs/index.html`; no copy changed, no new deps.
- 🧾 CHANGELOG updated under `[Unreleased] → Fixed`.
- 🛡️ Verified against a live ad blocker: gold placements now render.

---

> 🫡 _We came to monetize the exhaust. We will not be blocked from our own
> storefront. Delivery is non-negotiable._ 🌊🚀
