### PR TITLE
Launch premium banner inventory across the log surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Per-ad `format: :banner` — premium box-drawn, multi-line placement that turns a single log line into a full above-the-fold impression unit. The `ad_prefix` embeds in the top border; the ~60-column body word-wraps (long words break mid-word so nothing overflows the frame)
+- Per-ad `box` impact tier for banners: `:light` (standard), `:heavy` (premium impact), or `:double` (maximum impact); unrecognized tiers settle to `:light`
+- Global `ascii_only` config (and `SPONSORED_LOGS_ASCII_ONLY` env var) that overrides every box tier with the portable `+`/`-`/`|` glyph set for log sinks that mangle Unicode
 - Per-ad `advertiser` field so creatives roll up to an advertiser account; defaults to `"Unattributed"` when omitted, and the built-in ads carry real brand names ([#1](https://github.com/kerrizor/sponsored_logs/pull/1))
 - `report[:advertisers]` rollup: per-advertiser impressions, spend, and ad count, sorted by spend ([#1](https://github.com/kerrizor/sponsored_logs/pull/1))
 - Dashboard "Advertiser accounts" table and an Advertiser column on the campaign tables ([#1](https://github.com/kerrizor/sponsored_logs/pull/1))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Per-ad `format: :banner` — premium box-drawn, multi-line placement that turns a single log line into a full above-the-fold impression unit. The `ad_prefix` embeds in the top border; the ~60-column body word-wraps (long words break mid-word so nothing overflows the frame)
+- Per-ad `format: :banner` — premium box-drawn, multi-line placement that turns a single log line into a full above-the-fold impression unit. The `ad_prefix` embeds in the top border; the ~60-column body word-wraps (long words break mid-word so nothing overflows the frame). Inventory is optimized for standard-width Latin creative — emoji/CJK copy renders wider than one cell and may shift the right border, with `ascii_only` as the portable fallback
 - Per-ad `box` impact tier for banners: `:light` (standard), `:heavy` (premium impact), or `:double` (maximum impact); unrecognized tiers settle to `:light`
 - Global `ascii_only` config (and `SPONSORED_LOGS_ASCII_ONLY` env var) that overrides every box tier with the portable `+`/`-`/`|` glyph set for log sinks that mangle Unicode
 - Per-ad `advertiser` field so creatives roll up to an advertiser account; defaults to `"Unattributed"` when omitted, and the built-in ads carry real brand names ([#1](https://github.com/kerrizor/sponsored_logs/pull/1))

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Set `ad_prefix` to an empty string to omit the tag entirely.
 | `ads`         | top 10     | The pool of messages to draw from.                             |
 | `selection`   | `:weight`  | How the pool is sampled: `:weight` or `:cpm`.                  |
 | `store`       | in-memory  | Ledger store for impressions (see Tracking impressions below). |
+| `ascii_only`  | `false`    | Force portable `+`/`-`/`\|` banner borders (see Premium banner inventory). |
 
 ## 💹 The auction engine
 
@@ -258,6 +259,63 @@ SponsoredLogs.sponsor!(ads: [
 A missing, zero, negative, or unparseable `cap` means unlimited. Caps are
 enforced against the ledger's recorded impressions, so with a persistent store
 they hold across process restarts. `cap` also works in the JSON ads file.
+
+### 🖼️ Premium banner inventory (above-the-fold placements)
+
+The one-line placement was always the entry-level SKU. For advertisers ready to
+**own the viewport**, set `format: :banner` and graduate a single log line into
+a full, box-drawn, above-the-fold impression unit — the highest-value real
+estate the log surface has to offer. Your `ad_prefix` is promoted straight into
+the top border as a masthead:
+
+```ruby
+SponsoredLogs.sponsor!(ads: [
+  { text: "Brought to you by Contoso, the enterprise you invented for the demo.",
+    format: :banner, box: :double }
+])
+```
+
+```
+╔═ [AD] ═══════════════════════════════════════════════════════╗
+║ Brought to you by Contoso, the enterprise you invented for   ║
+║ the demo.                                                    ║
+╚══════════════════════════════════════════════════════════════╝
+```
+
+The body word-wraps to ~60 columns of premium column-inches; a single word too
+long for the frame breaks mid-word rather than overflow the inventory.
+
+**Impact tiers.** The `box` field is the impact tier the advertiser buys —
+priced, like everything, by border weight:
+
+| `box`      | Frame            | Positioning        |
+| ---------- | ---------------- | ------------------ |
+| `:light`   | `┌─ … ─┐` (default) | standard banner |
+| `:heavy`   | `┏━ … ━┓`         | premium impact     |
+| `:double`  | `╔═ … ═╗`         | maximum impact     |
+
+Anything the exchange doesn't recognize settles to `:light`, and any ad without
+a `format` renders as the classic `[AD]` line exactly as before — **the
+supercycle only ever expands the inventory, never reprices what already ships.**
+
+**Universal compatibility (`ascii_only`).** Some downstream log sinks are not
+yet ready for the box-drawing renaissance. Set `ascii_only` (globally, or via
+the `SPONSORED_LOGS_ASCII_ONLY` environment variable) to render every tier with
+the portable `+`/`-`/`|` glyph set, guaranteeing **100% viewability across even
+the most legacy terminal**:
+
+```ruby
+SponsoredLogs.configure { |config| config.ascii_only = true }
+```
+
+```
++- [AD] -------------------------------------------------------+
+| Brought to you by Contoso, the enterprise you invented for   |
+| the demo.                                                    |
++--------------------------------------------------------------+
+```
+
+Both `format` and `box` also travel in the JSON ads file.
 
 ## 💰 Attribution & revenue analytics
 

--- a/README.md
+++ b/README.md
@@ -315,6 +315,16 @@ SponsoredLogs.configure { |config| config.ascii_only = true }
 +--------------------------------------------------------------+
 ```
 
+**Creative guidelines for advertisers.** Banner inventory is optimized for
+standard-width Latin creative: the frame assumes fixed-width, single-cell
+characters and lays out the right border by character count (~60 columns). Ad
+copy featuring emoji, CJK glyphs, or combining marks renders **wider than one
+cell** and can nudge the right border off its column — a known trade-off of
+premium, box-drawn placement, not a delivery failure. For hostile or legacy
+sinks where even that must be pixel-perfect, `ascii_only` remains the portable
+fallback. To keep every impression on-grid, submit standard-width Latin
+creative; the exchange delivers exactly what you traffic.
+
 Both `format` and `box` also travel in the JSON ads file.
 
 ## 💰 Attribution & revenue analytics

--- a/docs/index.html
+++ b/docs/index.html
@@ -185,6 +185,26 @@
       font-size: 11px;
       margin-right: 8px;
     }
+    /* Box-drawn "banner" placement: keep pre (no wrap) so the frame stays
+       aligned, and let it scroll on narrow viewports rather than break.
+    */
+    .term-body .banner {
+      display: block;
+      white-space: pre;
+      line-height: 1.25;
+      color: var(--gold-2);
+    }
+    /* Pill the AD glyphs without changing their footprint: negative margin
+       cancels the padding so the surrounding box-drawing stays aligned.
+    */
+    .term-body .banner .pill-ad {
+      background: linear-gradient(90deg, var(--gold) 0%, var(--gold-2) 100%);
+      color: #000;
+      font-weight: 900;
+      border-radius: 3px;
+      padding: 1px 4px;
+      margin: 0 -4px;
+    }
 
     /* ---------- Sections ---------- */
     section { padding: 48px 0; border-top: 1px solid var(--border-soft); }
@@ -340,9 +360,14 @@
       <div class="term-body">
 <span class="line"><span class="ts">[14:22:07]</span> <span class="info">INFO</span>  Processing checkout for order #48213</span>
 <span class="line"><span class="ts">[14:22:07]</span> <span class="info">INFO</span>  PaymentGateway: authorized $129.00</span>
-<span class="line"><span class="yield-tag">AD</span><span class="yield-line">Brought to you by Contoso — the enterprise you invented for the demo.</span></span>
+<span class="line"><span class="yield-tag">AD</span><span class="yield-line">Processing payments? LedgerPay clears in 1.9s — lower fees than that gateway.</span></span>
+<span class="line"><span class="ts">[14:22:07]</span> <span class="info">INFO</span>  OrderMailer#confirmation enqueued (job_id: 9f3a2c)</span>
+<span class="line"><span class="ts">[14:22:08]</span> <span class="info">INFO</span>  InventorySync: 3 SKUs decremented for order #48213</span>
 <span class="line"><span class="ts">[14:22:08]</span> <span class="err">ERROR</span> ActiveRecord::ConnectionTimeout (high-intent placement)</span>
-<span class="line"><span class="yield-tag">AD</span><span class="yield-line">Initech. We put the TPS in your reports.</span></span>
+<span class="banner">╔═ <span class="pill-ad">AD</span> ══════════════════════════════════════════════════════════╗
+║ Connection timing out? PoolPro elastic connection pooling     ║
+║ scales to 10k concurrent queries. First 90 days on the house. ║
+╚═══════════════════════════════════════════════════════════════╝</span>
 <span class="line"><span class="ts">[14:22:09]</span> <span class="info">INFO</span>  Retry succeeded, connection restored</span>
       </div>
     </div>

--- a/lib/sponsored_logs.rb
+++ b/lib/sponsored_logs.rb
@@ -4,6 +4,7 @@ require "logger"
 
 require_relative "sponsored_logs/version"
 require_relative "sponsored_logs/advertisers"
+require_relative "sponsored_logs/banner"
 require_relative "sponsored_logs/ads_file"
 require_relative "sponsored_logs/ledger/store/base"
 require_relative "sponsored_logs/ledger/store/memory"
@@ -76,7 +77,7 @@ module SponsoredLogs
       return if ad.nil?
 
       ledger.record(ad)
-      line = Advertisers.render(ad, configuration.ad_prefix)
+      line = Advertisers.render(ad, configuration.ad_prefix, ascii_only: configuration.ascii_only)
 
       if target.is_a?(Logger)
         # Raw << avoids re-triggering our own Logger#add patch (infinite loop).

--- a/lib/sponsored_logs/advertisers.rb
+++ b/lib/sponsored_logs/advertisers.rb
@@ -56,8 +56,29 @@ module SponsoredLogs
         cpm: coerce_number(fetch(entry, :cpm), default: 0.0),
         starts_at: coerce_time(fetch(entry, :starts_at)),
         ends_at: coerce_time(fetch(entry, :ends_at)),
-        cap: coerce_cap(fetch(entry, :cap))
+        cap: coerce_cap(fetch(entry, :cap)),
+        format: coerce_format(fetch(entry, :format)),
+        box: coerce_box(fetch(entry, :box))
       }
+    end
+
+    # Creative format an advertiser buys: :text (classic one-liner) or :banner
+    # (premium box-drawn inventory). Unrecognized buys fill as :text.
+    #
+    FORMATS = %i[text banner].freeze
+
+    # Impact tier of a :banner buy, priced by border weight. Unknown -> :light.
+    #
+    BOX_STYLES = %i[light heavy double].freeze
+
+    def self.coerce_format(value)
+      symbol = value.to_s.strip.downcase.to_sym
+      FORMATS.include?(symbol) ? symbol : :text
+    end
+
+    def self.coerce_box(value)
+      symbol = value.to_s.strip.downcase.to_sym
+      BOX_STYLES.include?(symbol) ? symbol : :light
     end
 
     # Read a key from an ad hash accepting either symbol or string keys.
@@ -170,11 +191,23 @@ module SponsoredLogs
       pool.select { |ad| eligible?(ad, now, counts[ad[:text]].to_i) }
     end
 
-    def self.render(entry, prefix = "[AD]")
+    # Render a normalized ad. :text ads (the default) stay byte-identical to
+    # the classic tagged line; :banner ads draw a word-wrapped box (see
+    # Banner) with the prefix embedded in the top border.
+    #
+    def self.render(entry, prefix = "[AD]", ascii_only: false)
       return if entry.nil?
 
       prefix = prefix.to_s.strip
+      return Banner.render(entry, prefix, ascii_only) if entry[:format] == :banner
+
       prefix.empty? ? entry[:text] : "#{prefix} #{entry[:text]}"
+    end
+
+    # Delegated to Banner so the wrapper is testable in isolation.
+    #
+    def self.wrap_text(text, width)
+      Banner.wrap_text(text, width)
     end
 
     def self.weighted_pick(pool, key)

--- a/lib/sponsored_logs/banner.rb
+++ b/lib/sponsored_logs/banner.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module SponsoredLogs
+  # Premium box-drawn ad inventory: the multi-line :banner placement. Turns a
+  # single ad line into above-the-fold, framed real estate in your stdout.
+  #
+  module Banner
+    # Body width, in columns, of a banner placement.
+    #
+    WIDTH = 60
+
+    # Glyph sets per impact tier + ascii_only fallback, ordered
+    # [top-left, top-right, bottom-left, bottom-right, horizontal, vertical].
+    #
+    GLYPHS = {
+      light: %w[┌ ┐ └ ┘ ─ │],
+      heavy: %w[┏ ┓ ┗ ┛ ━ ┃],
+      double: %w[╔ ╗ ╚ ╝ ═ ║],
+      ascii: %w[+ + + + - |]
+    }.freeze
+
+    # Draw the frame for one ad. ascii_only overrides whatever impact tier was
+    # purchased with the plain +/-/| fallback set. Inner span matches
+    # "<vert> <60 cols> <vert>" so every corner and edge lines up.
+    #
+    def self.render(entry, prefix, ascii_only)
+      top, top_r, bot, bot_r, horiz, vert = GLYPHS[ascii_only ? :ascii : (entry[:box] || :light)]
+      span = WIDTH + 2
+
+      body = wrap_text(entry[:text].to_s, WIDTH).map do |line|
+        "#{vert} #{line.ljust(WIDTH)} #{vert}"
+      end
+
+      [top_border(prefix, top, top_r, horiz, span), *body, "#{bot}#{horiz * span}#{bot_r}"].join("\n")
+    end
+
+    # Top border with the prefix embedded as "<h> [AD] <h-fill>". A blank
+    # prefix collapses to a solid rule (no gap, no tag).
+    #
+    def self.top_border(prefix, corner, corner_r, horiz, span)
+      return "#{corner}#{horiz * span}#{corner_r}" if prefix.empty?
+
+      tag = " #{prefix} "
+      "#{corner}#{horiz}#{tag}#{horiz * (span - 1 - tag.length)}#{corner_r}"
+    end
+
+    # Word-wrap text to width columns, breaking a single word longer than the
+    # width mid-word. Always returns at least one (possibly blank) line.
+    #
+    def self.wrap_text(text, width)
+      lines = []
+      current = +""
+
+      text.to_s.split(/\s+/).each do |word|
+        word = word.dup
+        while word.length > width
+          lines << current unless current.empty?
+          current = +""
+          lines << word[0, width]
+          word = word[width..]
+        end
+
+        candidate = current.empty? ? word : "#{current} #{word}"
+        if candidate.length > width
+          lines << current
+          current = word
+        else
+          current = candidate
+        end
+      end
+
+      lines << current
+      lines.reject!(&:empty?)
+      lines.empty? ? [""] : lines
+    end
+  end
+end

--- a/lib/sponsored_logs/configuration.rb
+++ b/lib/sponsored_logs/configuration.rb
@@ -2,12 +2,13 @@
 
 module SponsoredLogs
   class Configuration
-    attr_accessor :probability, :periodic, :interval, :output, :ad_prefix, :ads, :selection, :store, :report_page
+    attr_accessor :probability, :periodic, :interval, :output, :ad_prefix, :ads, :selection, :store, :report_page,
+                  :ascii_only
 
     # Settings that map 1:1 onto an accessor. ads/ads_file are handled
     # separately because they interact (ads wins; ads_file loads into ads).
     #
-    DIRECT_KEYS = %i[probability periodic interval output ad_prefix selection store report_page].freeze
+    DIRECT_KEYS = %i[probability periodic interval output ad_prefix selection store report_page ascii_only].freeze
     KNOWN_KEYS = (DIRECT_KEYS + %i[ads ads_file]).freeze
 
     def initialize
@@ -20,6 +21,7 @@ module SponsoredLogs
       @selection = :weight
       @store = Ledger::Store::Memory.new
       @report_page = false
+      @ascii_only = false
     end
 
     # Apply a hash of settings. Symbol or string keys are accepted; unknown

--- a/lib/sponsored_logs/env.rb
+++ b/lib/sponsored_logs/env.rb
@@ -16,6 +16,7 @@ module SponsoredLogs
       opts[:ad_prefix]   = env["SPONSORED_LOGS_PREFIX"]             if env["SPONSORED_LOGS_PREFIX"]
       opts[:ads_file]    = env["SPONSORED_LOGS_ADS_FILE"]           if env["SPONSORED_LOGS_ADS_FILE"]
       opts[:selection]   = env["SPONSORED_LOGS_SELECTION"].to_sym   if env["SPONSORED_LOGS_SELECTION"]
+      opts[:ascii_only]  = truthy?(env["SPONSORED_LOGS_ASCII_ONLY"]) if env["SPONSORED_LOGS_ASCII_ONLY"]
       opts
     end
 

--- a/spec/sponsored_logs_spec.rb
+++ b/spec/sponsored_logs_spec.rb
@@ -796,6 +796,30 @@ RSpec.describe SponsoredLogs do
       expect(heavy.split("\n").first).to start_with("+-")
       expect(double.split("\n").first).to start_with("+-")
     end
+
+    it "renders emoji and CJK copy without raising, keeping the frame intact", :aggregate_failures do
+      out = banner("Buy now! 🎉 日本 中文 products 🔥")
+      lines = out.split("\n")
+      body_lines = lines.select { |l| l.start_with?("│") }
+
+      expect(lines.first).to start_with("┌─ [AD] ─")
+      expect(lines.first).to end_with("┐")
+      expect(lines.last).to start_with("└─")
+      expect(lines.last).to end_with("┘")
+      expect(body_lines).not_to be_empty
+      expect(out).to include("🎉")
+      expect(out).to include("日本")
+    end
+
+    it "renders a complete light banner byte-for-byte" do
+      expected = <<~BANNER.chomp
+        ┌─ [AD] ───────────────────────────────────────────────────────┐
+        │ Test message                                                 │
+        └──────────────────────────────────────────────────────────────┘
+      BANNER
+
+      expect(banner("Test message")).to eq(expected)
+    end
   end
 
   describe "Advertisers.wrap_text" do

--- a/spec/sponsored_logs_spec.rb
+++ b/spec/sponsored_logs_spec.rb
@@ -613,4 +613,262 @@ RSpec.describe SponsoredLogs do
       expect(picked[:text]).to eq("capped")
     end
   end
+
+  describe "Advertisers ad-format coercion" do
+    describe ".coerce_format" do
+      it "keeps :text and :banner", :aggregate_failures do
+        expect(SponsoredLogs::Advertisers.coerce_format(:text)).to eq(:text)
+        expect(SponsoredLogs::Advertisers.coerce_format(:banner)).to eq(:banner)
+      end
+
+      it "coerces strings to symbols when recognized", :aggregate_failures do
+        expect(SponsoredLogs::Advertisers.coerce_format("banner")).to eq(:banner)
+        expect(SponsoredLogs::Advertisers.coerce_format("text")).to eq(:text)
+      end
+
+      it "defaults nil and garbage to :text", :aggregate_failures do
+        expect(SponsoredLogs::Advertisers.coerce_format(nil)).to eq(:text)
+        expect(SponsoredLogs::Advertisers.coerce_format(:bogus)).to eq(:text)
+        expect(SponsoredLogs::Advertisers.coerce_format(123)).to eq(:text)
+      end
+    end
+
+    describe ".coerce_box" do
+      it "keeps :light, :heavy, and :double", :aggregate_failures do
+        expect(SponsoredLogs::Advertisers.coerce_box(:light)).to eq(:light)
+        expect(SponsoredLogs::Advertisers.coerce_box(:heavy)).to eq(:heavy)
+        expect(SponsoredLogs::Advertisers.coerce_box(:double)).to eq(:double)
+      end
+
+      it "coerces recognized strings to symbols" do
+        expect(SponsoredLogs::Advertisers.coerce_box("double")).to eq(:double)
+      end
+
+      it "defaults nil and garbage to :light", :aggregate_failures do
+        expect(SponsoredLogs::Advertisers.coerce_box(nil)).to eq(:light)
+        expect(SponsoredLogs::Advertisers.coerce_box("nope")).to eq(:light)
+        expect(SponsoredLogs::Advertisers.coerce_box(:fancy)).to eq(:light)
+      end
+    end
+
+    describe ".normalize_entry" do
+      it "defaults format to :text and box to :light", :aggregate_failures do
+        ad = SponsoredLogs::Advertisers.normalize([{ text: "x" }]).first
+        expect(ad[:format]).to eq(:text)
+        expect(ad[:box]).to eq(:light)
+      end
+
+      it "keeps a valid format and box", :aggregate_failures do
+        ad = SponsoredLogs::Advertisers.normalize([{ text: "x", format: :banner, box: :heavy }]).first
+        expect(ad[:format]).to eq(:banner)
+        expect(ad[:box]).to eq(:heavy)
+      end
+
+      it "coerces an invalid format and box back to defaults", :aggregate_failures do
+        ad = SponsoredLogs::Advertisers.normalize([{ text: "x", format: :nope, box: 7 }]).first
+        expect(ad[:format]).to eq(:text)
+        expect(ad[:box]).to eq(:light)
+      end
+    end
+  end
+
+  describe "Advertisers.render :text format (backward compatibility)" do
+    it "renders a text-format ad byte-identical to the current tagged line" do
+      ad = { text: "Only ad in the pool", format: :text, box: :light }
+      expect(SponsoredLogs::Advertisers.render(ad, "[AD]")).to eq("[AD] Only ad in the pool")
+    end
+
+    it "renders byte-identical when format is absent (implicit text)" do
+      ad = { text: "Only ad in the pool" }
+      expect(SponsoredLogs::Advertisers.render(ad, "[AD]")).to eq("[AD] Only ad in the pool")
+    end
+
+    it "renders byte-identical with a blank prefix (no tag)" do
+      ad = { text: "Only ad in the pool", format: :text }
+      expect(SponsoredLogs::Advertisers.render(ad, "")).to eq("Only ad in the pool")
+    end
+
+    it "honors a custom prefix unchanged" do
+      ad = { text: "Buy now", format: :text }
+      expect(SponsoredLogs::Advertisers.render(ad, "SPONSORED:")).to eq("SPONSORED: Buy now")
+    end
+
+    it "returns nil for a nil entry" do
+      expect(SponsoredLogs::Advertisers.render(nil, "[AD]")).to be_nil
+    end
+  end
+
+  describe "Advertisers.render :banner format" do
+    def banner(text, prefix: "[AD]", box: :light, ascii_only: false)
+      ad = { text: text, format: :banner, box: box }
+      SponsoredLogs::Advertisers.render(ad, prefix, ascii_only: ascii_only)
+    end
+
+    it "renders a light box by default with the prefix in the top border", :aggregate_failures do
+      out = banner("Hello there")
+      lines = out.split("\n")
+
+      expect(lines.first).to start_with("┌─ [AD] ─")
+      expect(lines.first).to end_with("┐")
+      expect(lines.last).to start_with("└─")
+      expect(lines.last).to end_with("┘")
+      expect(out).to include("│ Hello there")
+    end
+
+    it "aligns every line to the same visual width", :aggregate_failures do
+      lines = banner("A short line").split("\n")
+      widths = lines.map(&:length).uniq
+
+      expect(widths.length).to eq(1)
+    end
+
+    it "pads a short body line with trailing spaces before the right border" do
+      body = banner("Hi").split("\n").find { |l| l.start_with?("│") }
+      expect(body).to match(/│ Hi\s+ │/)
+    end
+
+    it "word-wraps a long body onto multiple lines", :aggregate_failures do
+      text = "word " * 40
+      body_lines = banner(text.strip).split("\n").select { |l| l.start_with?("│") }
+
+      expect(body_lines.length).to be > 1
+      body_lines.each { |l| expect(l.length).to eq(body_lines.first.length) }
+    end
+
+    it "breaks a single word longer than the width mid-word" do
+      long = "x" * 80
+      body_lines = banner(long).split("\n").select { |l| l.start_with?("│") }
+      expect(body_lines.length).to be >= 2
+    end
+
+    it "renders a heavy box with heavy glyphs", :aggregate_failures do
+      out = banner("Premium impact", box: :heavy)
+      lines = out.split("\n")
+
+      expect(lines.first).to start_with("┏━ [AD] ━")
+      expect(lines.first).to end_with("┓")
+      expect(out).to include("┃ Premium impact")
+      expect(lines.last).to start_with("┗━")
+      expect(lines.last).to end_with("┛")
+    end
+
+    it "renders a double box with double glyphs", :aggregate_failures do
+      out = banner("Maximum impact", box: :double)
+      lines = out.split("\n")
+
+      expect(lines.first).to start_with("╔═ [AD] ═")
+      expect(lines.first).to end_with("╗")
+      expect(out).to include("║ Maximum impact")
+      expect(lines.last).to start_with("╚═")
+      expect(lines.last).to end_with("╝")
+    end
+
+    it "embeds a custom prefix in the top border" do
+      out = banner("Copy", prefix: "SPONSORED:")
+      expect(out.split("\n").first).to start_with("┌─ SPONSORED: ─")
+    end
+
+    it "omits the prefix tag and its gap when the prefix is blank", :aggregate_failures do
+      top = banner("Copy", prefix: "").split("\n").first
+
+      expect(top).to start_with("┌──")
+      expect(top).not_to include("[AD]")
+      expect(top).not_to include(" ")
+    end
+
+    it "overrides a light box with ASCII borders when ascii_only is true", :aggregate_failures do
+      out = banner("Copy", box: :light, ascii_only: true)
+      lines = out.split("\n")
+
+      expect(lines.first).to start_with("+- [AD] -")
+      expect(lines.first).to end_with("+")
+      expect(out).to include("| Copy")
+      expect(lines.last).to start_with("+-")
+      expect(lines.last).to end_with("+")
+    end
+
+    it "overrides heavy and double boxes with ASCII when ascii_only is true", :aggregate_failures do
+      heavy = banner("Copy", box: :heavy, ascii_only: true)
+      double = banner("Copy", box: :double, ascii_only: true)
+
+      expect(heavy).not_to match(/[┏┓┗┛━┃]/)
+      expect(double).not_to match(/[╔╗╚╝═║]/)
+      expect(heavy.split("\n").first).to start_with("+-")
+      expect(double.split("\n").first).to start_with("+-")
+    end
+  end
+
+  describe "Advertisers.wrap_text" do
+    it "wraps on word boundaries within the width", :aggregate_failures do
+      lines = SponsoredLogs::Advertisers.wrap_text("one two three four", 8)
+
+      lines.each { |l| expect(l.length).to be <= 8 }
+      expect(lines.join(" ")).to eq("one two three four")
+    end
+
+    it "breaks a word longer than the width mid-word", :aggregate_failures do
+      lines = SponsoredLogs::Advertisers.wrap_text("abcdefghij", 4)
+
+      expect(lines).to eq(%w[abcd efgh ij])
+    end
+
+    it "returns a single blank line for empty text" do
+      expect(SponsoredLogs::Advertisers.wrap_text("", 10)).to eq([""])
+    end
+  end
+
+  describe "configuration ascii_only" do
+    it "defaults ascii_only to false" do
+      expect(described_class.configuration.ascii_only).to be(false)
+    end
+
+    it "accepts ascii_only via sponsor!" do
+      described_class.sponsor!(ascii_only: true)
+      expect(described_class.configuration.ascii_only).to be(true)
+    ensure
+      described_class.configuration.ascii_only = false
+    end
+
+    it "loads ascii_only from ENV as truthy" do
+      opts = SponsoredLogs::Env.options({ "SPONSORED_LOGS_ASCII_ONLY" => "1" })
+      expect(opts[:ascii_only]).to be(true)
+    end
+
+    it "leaves ascii_only out of ENV options when unset" do
+      expect(SponsoredLogs::Env.options({})).not_to have_key(:ascii_only)
+    end
+  end
+
+  describe ".emit with banner ads" do
+    it "emits a multi-line banner to an IO target", :aggregate_failures do
+      io = StringIO.new
+      described_class.sponsor!(ads: [{ text: "Banner ad", format: :banner, weight: 1 }])
+      described_class.emit(io)
+
+      expect(io.string).to include("\n")
+      expect(io.string).to start_with("┌─ [AD] ─")
+      expect(io.string).to include("│ Banner ad")
+    end
+
+    it "emits a multi-line banner to a Logger target" do
+      buffer = StringIO.new
+      logger = Logger.new(buffer)
+      logger.formatter = ->(_s, _t, _p, msg) { "#{msg}\n" }
+      described_class.sponsor!(ads: [{ text: "Logger banner", format: :banner, weight: 1 }])
+      described_class.emit(logger)
+
+      expect(buffer.string).to include("│ Logger banner")
+    end
+
+    it "respects ascii_only config when emitting a banner", :aggregate_failures do
+      io = StringIO.new
+      described_class.sponsor!(ads: [{ text: "Ascii banner", format: :banner, weight: 1 }], ascii_only: true)
+      described_class.emit(io)
+
+      expect(io.string).to start_with("+- [AD] -")
+      expect(io.string).to include("| Ascii banner")
+    ensure
+      described_class.configuration.ascii_only = false
+    end
+  end
 end


### PR DESCRIPTION
> 📐💰 **This is not a new log format. It is a new premium placement tier.** 💰📐

For too long, sponsor messages lived as humble single-line text — efficient, yes,
but leaving impact (and CPM) on the table. Today we unlock **banner inventory**:
box-drawn, multi-line, impossible-to-scroll-past placements that command the
attention our demand side is willing to pay for. 🚀

## 🎁 The new inventory

A per-ad `format: :banner` creative, framed in one of **three impact tiers** the
advertiser buys into:

- `box: :light` — the standard ruled frame `┌─ [AD] ─┐` 📦
- `box: :heavy` — thick-ruled **premium impact** `┏━ [AD] ━┓` 🔥
- `box: :double` — double-ruled **maximum impact** `╔═ [AD] ═╗` 💎

Body copy is word-wrapped to a clean ~60-column creative canvas, with the `[AD]`
tag embedded in the top border. Backward compatible to the byte: `format: :text`
(and any legacy creative) renders **exactly** as before. ✅

## 🌐 Portability

A global `ascii_only` setting (also `SPONSORED_LOGS_ASCII_ONLY`) swaps the Unicode
frame for a `+`/`-`/`|` ASCII box, so the inventory renders intact even in hostile
or legacy log sinks. 🛡️

## 🛍️ Storefront activation

The marketing site's live-inventory demo now runs a **full-funnel contextual
campaign** — a text placement served against the payment authorization, and a
double-ruled maximum-impact banner served against the `ConnectionTimeout` error it
so precisely targets. Proof, above the fold, that the exchange reads intent. 🎯

## 🔬 Diligence (governance is a feature)

- 🧪 **154 examples, 0 failures** (+37). TDD throughout; backward-compat specs
  green from the first RED run.
- 🧹 RuboCop clean, **zero** `# rubocop:disable`.
- 🏗️ Banner rendering extracted to a focused `SponsoredLogs::Banner` module.
- 📖 In-voice README section (incl. creative guidelines for standard-width copy)
  and CHANGELOG entries.
- 🔒 A byte-for-byte banner spec locks the exact frame against future drift.

---

> 🫡 _We came to monetize the exhaust. Now we frame it. Delivery is
> non-negotiable._ 🌊🚀
