### PR TITLE
Activate sponsor inventory across the documentation surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Activated sponsor inventory across the project's own documentation surface: the README and this changelog now carry host-read placements between sections. Premium above-the-fold attention should not go unmonetized simply because it happens to be ours
 - Per-ad `format: :banner` — premium box-drawn, multi-line placement that turns a single log line into a full above-the-fold impression unit. The `ad_prefix` embeds in the top border; the ~60-column body word-wraps (long words break mid-word so nothing overflows the frame). Inventory is optimized for standard-width Latin creative — emoji/CJK copy renders wider than one cell and may shift the right border, with `ascii_only` as the portable fallback
 - Per-ad `box` impact tier for banners: `:light` (standard), `:heavy` (premium impact), or `:double` (maximum impact); unrecognized tiers settle to `:light`
 - Global `ascii_only` config (and `SPONSORED_LOGS_ASCII_ONLY` env var) that overrides every box tier with the portable `+`/`-`/`|` glyph set for log sinks that mangle Unicode
@@ -43,6 +44,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Refreshed the dashboard screenshot in the README to reflect the Command Center
 - Reordered the README to lead with the Agentic Advantage, and sprinkled emoji throughout — the machine audience deserves a warm welcome
+
+> `[AD]` This release cycle sponsored by **ShipFaster CI** — because your
+> changelog should ship as fast as your excuses. shipfaster.dev/logs
 
 ## [0.1.0] - 2026-09-06
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ Then run:
 bundle install
 ```
 
+> `[AD]` This installation brought to you by **DepGuard** — the only
+> dependency scanner that reads your Gemfile at the speed of regret. Your
+> `bundle install` deserves a sponsor. depguard.dev/logs
+
 ## ⚡ Usage
 
 > Activation is opt-in — because at SponsoredLogs, **trust is our north-star
@@ -171,6 +175,14 @@ Set `ad_prefix` to an empty string to omit the tag entirely.
 | `selection`   | `:weight`  | How the pool is sampled: `:weight` or `:cpm`.                  |
 | `store`       | in-memory  | Ledger store for impressions (see Tracking impressions below). |
 | `ascii_only`  | `false`    | Force portable `+`/`-`/`\|` banner borders (see Premium banner inventory). |
+
+```
+╔═ [AD] ════════════════════════════════════════════════════════╗
+║ Configuring by hand? YieldOS auto-tunes your fill rate with   ║
+║ machine-speed precision — maximum-impact placement for teams  ║
+║ who'd rather ship than tweak. First 90 days on the house.     ║
+╚═══════════════════════════════════════════════════════════════╝
+```
 
 ## 💹 The auction engine
 


### PR DESCRIPTION
> 📄💸 **The last untapped surface was the documentation itself.** 💸📄

We preach that every line you log is a line you're leaving on the table — yet
the project's own README and changelog have been serving premium, above-the-fold
attention to the highest-intent audience imaginable (developers and agents
evaluating the platform) entirely unmonetized. That oversight ends today. We
dogfood the thesis. 🚀

## 🛍️ New inventory activated

- 🏷️ **Text placement after Installation** — served against `bundle install`,
  contextually matched to dependency tooling.
- 💎 **Maximum-impact double-ruled banner after the Configuration table** —
  prime real estate, right before the auction engine.
- 📒 **Release-cycle sponsor line in the changelog** — because your changelog
  should ship as fast as your excuses.

All creative runs against **contextually relevant** placements — the exchange
reads intent even in Markdown. 🎯

## 🔬 Diligence

- 📐 Banner is byte-aligned (verified by character count, not byte count) and
  fenced so the frame renders intact on GitHub.
- 🏢 All advertisers are fictional (DepGuard, YieldOS, ShipFaster CI) — no
  named-brand exposure.
- 🧾 Documented the activation in the changelog, which is now, fittingly,
  itself sponsored inventory. No code, no dependencies, no behavior change.

---

> 🫡 _We didn't add ads to the docs. We recognized the revenue that was always
> there. Monetize the exhaust — even the Markdown._ 🌊
