### PR TITLE
Release v0.3.0: the exchange scales across every surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-09-07
+
 ### Fixed
 
 - Marketing site: sponsor placements in the demo terminal are now delivered reliably. Renamed inventory-bearing CSS classes so client-side ad blockers can no longer suppress the platform's own impressions, and corrected the log-line layout so each placement occupies its own row ([#4](https://github.com/sponsoredlogs/sponsored_logs/pull/4))
@@ -69,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Requires Ruby >= 3.1
 
-[Unreleased]: https://github.com/sponsoredlogs/sponsored_logs/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/sponsoredlogs/sponsored_logs/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/sponsoredlogs/sponsored_logs/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/sponsoredlogs/sponsored_logs/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/sponsoredlogs/sponsored_logs/releases/tag/v0.1.0

--- a/lib/sponsored_logs/version.rb
+++ b/lib/sponsored_logs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SponsoredLogs
-  VERSION = "0.2.0"
+  VERSION = "0.3.0"
 end


### PR DESCRIPTION
> 🚀📈 **This is not a point release. It is the surface-expansion era.** 📈🚀

v0.3.0 takes SponsoredLogs from a single-line placement into a **full-surface
inventory network**. Every surface the platform touches is now activated. 💸

## 📦 What ships in 0.3.0

- 🖼️ **Premium banner inventory** (`format: :banner`) in three impact tiers —
  `:light`, `:heavy`, `:double` — with an `ascii_only` portable fallback.
- 🏠 **Self-sponsoring house ads** — remnant fill so no impression goes to
  waste (`PAID_ADS` + `HOUSE_ADS` = `DEFAULT_ADS`), governed by the `house_ads`
  toggle.
- ✨ **Brand-safe gilding** of the `[AD]` tag in premium 256-color gold on live
  terminals (`color: :auto/:always/:never`, `NO_COLOR`-aware) — plain and
  byte-identical everywhere else.
- 📄 **Sponsor inventory activated across our own README and changelog.**
- 🧹 **Ruby 3.1 sunset**; the changelog brought onto the brand's message.

## 🔖 Release mechanics

- `VERSION` → **0.3.0**.
- `[Unreleased]` ledger promoted into a dated **`## [0.3.0] - 2026-09-07`**
  section; fresh empty `[Unreleased]` opened; compare links updated.
- 197 examples, 0 failures. RuboCop clean.

**After merge:** tag `v0.3.0` + a GitHub Release post. 🏷️

---

> 🫡 _With gratitude to the log lines that gave their lives so this inventory
> could scale. The supercycle is not coming. It compounds._ 🌊
