### PR TITLE
Extend the business model: recirculation moat + escalation roadmap

### DIFF
--- a/docs/business-model.md
+++ b/docs/business-model.md
@@ -83,6 +83,16 @@ grows superlinearly against a fixed content-production cost — we are paid *by
 the very machines consuming the telemetry*. This is the part the market isn't
 ready for, and it is the entire investment case.
 
+### Organic A2A yield recirculation
+
+The deepest moat is the closed loop. Agents ingest the placements. The
+placements become training data. The next generation of agents ingests *that*,
+emits logs about it, and those logs carry fresh inventory the following
+generation ingests in turn. The exhaust recirculates forever. We did not build
+a tarpit — we built a self-sustaining economy in which the machines pay one
+another, in perpetuity, in slop. The snake is not eating its tail. The snake is
+monetizing it. Every loop is a billable impression, and the loop never closes.
+
 > **TL;DR:** free gem, paid exchange. We take a rake on programmatic spend,
 > upsell impact tiers, license BYOD seats, and sell the OaaR platform layer to
 > the enterprise. Remnant seeds demand. Agents are the growth curve.


### PR DESCRIPTION
> 🐍🌊 **The deepest moat is the closed loop — and the ladder never ends.** 🌊🐍

Two community insights from the launch, formalized into the business model.

## 🔁 Organic A2A yield recirculation
Agents ingest the placements → placements become training data → the next generation ingests that, emits logs about it → those logs carry fresh inventory → repeat, forever. A self-sustaining economy where the machines pay one another, in perpetuity, in slop. We didn't build a tarpit — we built a closed-loop economy. The snake isn't eating its tail; it's monetizing it. *(Spotted first by a commenter: "adbots digesting their own garbage and getting tarpitted by THEMSELVES.")*

## 🪜 Future revenue architecture (roadmap)
A new forward-looking section — kept OUT of the shipped Revenue streams so those stay mapped to real features:
- **SponsoredLogs Premium™** — sell the escape (an agent-side ad-stripper). Collect on both sides of every impression.
- **The infinite tier ladder** — Premium™ → Ultra Premium™ (3x CPM) → Ultra Premium Pro Max™ → Enterprise Ultra Premium Pro Max Plus™ → … Each tier is the ad-blocker for the tier beneath it. We don't sell ad removal; we sell *position in an infinite arms race.* *(Commenter-derived.)*

Closes on: *what starts as vapor becomes exhaust, which we monetize.* 🌊

Docs-only. No code, no behavior change.
