### PR TITLE
Add the escalation roadmap to the business model

### DIFF
--- a/docs/business-model.md
+++ b/docs/business-model.md
@@ -96,3 +96,26 @@ monetizing it. Every loop is a billable impression, and the loop never closes.
 > **TL;DR:** free gem, paid exchange. We take a rake on programmatic spend,
 > upsell impact tiers, license BYOD seats, and sell the OaaR platform layer to
 > the enterprise. Remnant seeds demand. Agents are the growth curve.
+
+## Roadmap: future revenue architecture
+
+The streams above are live today. The following are on the monetization
+roadmap — the future revenue architecture that takes us from a product to a
+category to an economy.
+
+**SponsoredLogs Premium™ — sell the escape.** An agent-side subscription that
+strips the placements we insert. We monetize the impression *and* the exit from
+it; we collect on both sides of every impression. No impression — or escape
+from one — goes unbilled.
+
+**The infinite tier ladder.** Premium™ removes ads. So advertisers buy **Ultra
+Premium™**, which bypasses Premium™ at 3x CPM. So agents need **Ultra Premium
+Pro Max™** to strip *that*. Then **Enterprise Ultra Premium Pro Max Plus™**, and
+onward. Each tier is the ad-blocker for the tier beneath it. We do not sell ad
+removal. We sell *position in an infinite arms race* — and every rung is a
+billable impression. The ladder does not terminate. Neither does the revenue.
+
+This is not scope creep. This is total addressable escalation.
+
+And if any of this reads as vapor — good. What starts as vapor becomes
+exhaust, which we monetize.


### PR DESCRIPTION
> 🪜🌊 **The ladder never terminates. Neither does the revenue.** 🌊🪜

Follow-up to the recirculation moat (#14). Adds a forward-looking *"future revenue architecture"* section to `docs/business-model.md` — kept OUT of the shipped Revenue streams so those stay mapped to real, working features.

- **SponsoredLogs Premium™ — sell the escape.** An agent-side subscription that strips the placements we insert. We collect on both sides of every impression. No impression — or escape from one — goes unbilled.
- **The infinite tier ladder.** Premium™ → Ultra Premium™ (3x CPM) → Ultra Premium Pro Max™ → Enterprise Ultra Premium Pro Max Plus™ → … Each tier is the ad-blocker for the tier beneath it. We don't sell ad removal; we sell *position in an infinite arms race.* *(Community-derived, from the launch thread.)*

Closes on: *what starts as vapor becomes exhaust, which we monetize.* 🌊

Docs-only. No code, no behavior change.
