### PR TITLE
Give every creative a stable identity in the ledger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Identity is a moat.** Copy is a draft, not an account — an advertiser that rewrites its line is not a new advertiser. Every ad takes an optional `id`; set it and impressions, spend, and cap ride through a mid-flight rewrite, omit it and `id` falls back to a content hash of the text so nothing already booked moves. Two advertisers can even run the same line as separate books. Works in the JSON ads file
+
+### Changed
+
+- **The ledger settles by account, not by copy.** The store snapshot is now `{ id => {text:, impressions:, cpm:} }` — text rides along as a label so the Command Center still reads in plain English, but caps and reporting key on `id` end to end. Custom stores must return the new shape
+- **`text_digest` retires; `ad_id` takes the desk.** The ActiveRecord ledger keys on `ad_id`, which for a no-id ad is exactly the old text digest, so existing rows line up untouched. Existing installs rerun `rails g sponsored_logs:install` (or rename the column and its unique index). The Redis store keys on `id` too, so existing Redis tallies reset once on upgrade
+
 ## [0.3.1] - 2026-09-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -233,6 +233,26 @@ A missing `weight` defaults to `1`; a negative weight is treated as `0`. A
 missing `cpm` defaults to `0`. A pool that is empty, has only blank text, or
 sums to zero weight falls back to the built-in list.
 
+### 🪪 Stable ad identity (portfolio continuity)
+
+Copy is not identity — copy is a draft. An advertiser that rewrites its line is
+not a new account, and two advertisers that happen to write the same line are
+not one. Give each creative a stable `id` and its impressions, spend, and cap
+carry across every rewrite:
+
+```ruby
+SponsoredLogs.sponsor!(ads: [
+  { id: "acme-q3", text: "Acme: now with more Acme.", weight: 1, cap: 10_000 },
+  { id: "acme-q3", text: "Acme: even MORE Acme.",     weight: 1, cap: 10_000 } # same account, new copy
+])
+```
+
+Omit `id` and it defaults to a content hash of the text — exactly how the ledger
+has always keyed — so nothing already in flight moves. `id` works in the JSON
+ads file too. Tallies, cap governance, and the Command Center all settle by
+account, then read your copy back in plain English. **An advertiser should never
+have to re-earn its own history just to fix a typo.**
+
 ### 🗓️ Flighting (start and end dates)
 
 **Campaign flighting** — table stakes for any serious ad server, and we deliver

--- a/lib/generators/sponsored_logs/templates/create_sponsored_logs_impressions.rb.tt
+++ b/lib/generators/sponsored_logs/templates/create_sponsored_logs_impressions.rb.tt
@@ -3,7 +3,7 @@
 class CreateSponsoredLogsImpressions < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
   def change
     create_table :sponsored_logs_impressions do |t|
-      t.string  :text_digest, null: false
+      t.string  :ad_id,       null: false
       t.text    :text,        null: false
       t.integer :impressions, null: false, default: 0
       t.float   :cpm,         null: false, default: 0.0
@@ -11,6 +11,6 @@ class CreateSponsoredLogsImpressions < ActiveRecord::Migration[<%= ActiveRecord:
       t.timestamps
     end
 
-    add_index :sponsored_logs_impressions, :text_digest, unique: true
+    add_index :sponsored_logs_impressions, :ad_id, unique: true
   end
 end

--- a/lib/sponsored_logs.rb
+++ b/lib/sponsored_logs.rb
@@ -5,6 +5,7 @@ require "logger"
 require_relative "sponsored_logs/version"
 require_relative "sponsored_logs/color"
 require_relative "sponsored_logs/advertisers"
+require_relative "sponsored_logs/identity"
 require_relative "sponsored_logs/flight"
 require_relative "sponsored_logs/banner"
 require_relative "sponsored_logs/ads_file"
@@ -159,37 +160,49 @@ module SponsoredLogs
 
     private
 
-    # Map of ad text => normalized config metadata (weight/cpm/flight/cap),
+    # Map of ad id => normalized config metadata (text/weight/cpm/flight/cap),
     # used to enrich report rows and drive status.
     #
     def ad_metadata
-      Advertisers.normalize(configuration.ads).to_h { |ad| [ad[:text], ad] }
+      Advertisers.normalize(configuration.ads).to_h { |ad| [ad[:id], ad] }
     end
 
     # Partition every known ad (served or configured) into running / upcoming /
-    # finished report rows by flight-and-cap status.
+    # finished report rows by flight-and-cap status. Ads are keyed by stable id;
+    # the human-readable text comes from the served ledger entry or config meta.
     #
     def grouped_report_rows
       now = Time.now
       metas = ad_metadata
       counts = ledger.impression_counts
-      served = ledger.entries.to_h { |entry| [entry.text, entry] }
+      served = ledger.entries.to_h { |entry| [entry.id, entry] }
 
       grouped = Hash.new { |h, k| h[k] = [] }
-
-      (served.keys + metas.keys).uniq.each do |text|
-        meta = metas[text] || {}
-        status = Advertisers.status(meta, now, counts[text].to_i)
-        row = report_row(text, meta, served[text], status)
-
-        case status
-        when :scheduled then grouped[:upcoming] << row
-        when :ended, :exhausted then grouped[:finished] << row
-        else grouped[:running] << row if served[text]
-        end
+      (served.keys + metas.keys).uniq.each do |id|
+        meta = metas[id] || {}
+        entry = served[id]
+        bucket, row = report_bucket_for(meta, entry, now, counts[id].to_i)
+        grouped[bucket] << row if bucket
       end
 
       grouped
+    end
+
+    # Classify one ad into its report bucket (:running / :upcoming / :finished)
+    # and build its row. Text comes from the served ledger entry (latest copy)
+    # or, for an unserved configured ad, its config meta. Running rows are
+    # impression-driven, so an unserved running ad returns a nil bucket.
+    #
+    def report_bucket_for(meta, entry, now, count)
+      text = entry ? entry.text : meta[:text]
+      status = Advertisers.status(meta, now, count)
+      row = report_row(text, meta, entry, status)
+
+      case status
+      when :scheduled then [:upcoming, row]
+      when :ended, :exhausted then [:finished, row]
+      else entry ? [:running, row] : [nil, row]
+      end
     end
 
     # A single report row. Impressions/spend come from the ledger entry when the

--- a/lib/sponsored_logs/advertisers.rb
+++ b/lib/sponsored_logs/advertisers.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "time"
+require "digest"
 
 module SponsoredLogs
   module Advertisers
@@ -73,6 +74,7 @@ module SponsoredLogs
       return if text.empty?
 
       {
+        id: Identity.coerce_id(fetch(entry, :id), text),
         advertiser: coerce_advertiser(fetch(entry, :advertiser)),
         text: text,
         weight: coerce_number(fetch(entry, :weight), default: 1.0),
@@ -197,7 +199,7 @@ module SponsoredLogs
 
     # Pick one normalized ad entry using the given selection mode, considering
     # only ads eligible at `now` -- live within their flight window and under
-    # their impression cap (counts is a text => impressions map). In :cpm mode
+    # their impression cap (counts is an id => impressions map). In :cpm mode
     # the cpm drives the odds; if every eligible cpm is 0 we fall back to manual
     # weights so selection never stalls.
     #
@@ -233,11 +235,12 @@ module SponsoredLogs
       house_ads? ? DEFAULT_ADS : PAID_ADS
     end
 
-    # Texts that identify house inventory, used to exclude house ads from
+    # Ids that identify house inventory, used to exclude house ads from
     # selection when the toggle is off (they can arrive via a user-supplied
-    # DEFAULT_ADS pool, not just the fallback).
+    # DEFAULT_ADS pool, not just the fallback). Keyed by id, not text, so
+    # editing house-ad copy can't break the match.
     #
-    HOUSE_TEXTS = HOUSE_ADS.map { |ad| ad[:text] }.freeze
+    HOUSE_IDS = HOUSE_ADS.map { |ad| Digest::SHA256.hexdigest(ad[:text]) }.freeze
 
     # Strip house creatives from a pool when the house_ads toggle is off; a
     # no-op when it is on. Keeps house ads out of rotation everywhere, not just
@@ -246,7 +249,7 @@ module SponsoredLogs
     def self.drop_house(pool)
       return pool if house_ads?
 
-      pool.reject { |ad| HOUSE_TEXTS.include?(ad[:text]) }
+      pool.reject { |ad| HOUSE_IDS.include?(Identity.id_for(ad)) }
     end
 
     # Whether the self-sponsoring house-ad inventory is enabled. Defaults to on
@@ -262,7 +265,7 @@ module SponsoredLogs
     end
 
     def self.eligible(pool, now, counts)
-      pool.select { |ad| eligible?(ad, now, counts[ad[:text]].to_i) }
+      pool.select { |ad| eligible?(ad, now, counts[Identity.id_for(ad)].to_i) }
     end
 
     # Render a normalized ad. :text ads (the default) stay byte-identical to

--- a/lib/sponsored_logs/identity.rb
+++ b/lib/sponsored_logs/identity.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "digest"
+
+module SponsoredLogs
+  # Stable ad identity. The ledger keys impressions on an ad's id, not its
+  # mutable text, so identical copy under different ids tallies separately and
+  # editing copy never resets a count. An absent/blank id falls back to
+  # SHA256(text), which is byte-compatible with the pre-0.4.0 text-keyed
+  # behavior and lines up with the ActiveRecord digest for zero-migration
+  # back-compat.
+  #
+  module Identity
+    module_function
+
+    # Resolve an explicit id (opt-in stability) or fall back to SHA256(text).
+    #
+    def coerce_id(value, text)
+      id = value.to_s.strip
+      id.empty? ? Digest::SHA256.hexdigest(text) : id
+    end
+
+    # The ledger key for an ad hash. Normalized ads carry :id; raw hashes
+    # recorded straight to a store fall back to the same SHA256(text) default,
+    # so both paths agree on identity. Accepts symbol- or string-keyed hashes.
+    #
+    def id_for(ad)
+      value = ad[:id] || ad["id"]
+      coerce_id(value, sanitize_text(ad[:text] || ad["text"]))
+    end
+
+    # Mirror Advertisers.sanitize_text so an id derived from raw text matches
+    # the id derived from normalized (sanitized) text for the same creative.
+    #
+    def sanitize_text(value)
+      value.to_s.gsub(Advertisers::CONTROL_CHARS, " ").strip
+    end
+  end
+end

--- a/lib/sponsored_logs/ledger/report.rb
+++ b/lib/sponsored_logs/ledger/report.rb
@@ -7,7 +7,7 @@ module SponsoredLogs
     # Spend for an ad is impressions / 1000.0 * cpm (cost per mille).
     #
     class Report
-      Entry = Struct.new(:text, :impressions, :cpm, :spend, keyword_init: true)
+      Entry = Struct.new(:id, :text, :impressions, :cpm, :spend, keyword_init: true)
 
       def initialize(store)
         @store = store
@@ -18,17 +18,18 @@ module SponsoredLogs
       end
 
       def total_impressions
-        @store.snapshot.sum { |_text, data| data[:impressions] }
+        @store.snapshot.sum { |_id, data| data[:impressions] }
       end
 
       def total_spend
-        @store.snapshot.sum { |_text, data| spend_for(data[:impressions], data[:cpm]) }
+        @store.snapshot.sum { |_id, data| spend_for(data[:impressions], data[:cpm]) }
       end
 
       def entries
-        @store.snapshot.map do |text, data|
+        @store.snapshot.map do |id, data|
           Entry.new(
-            text: text,
+            id: id,
+            text: data[:text],
             impressions: data[:impressions],
             cpm: data[:cpm].to_f,
             spend: spend_for(data[:impressions], data[:cpm])
@@ -36,7 +37,7 @@ module SponsoredLogs
         end
       end
 
-      # Map of ad text => recorded impressions, for cap enforcement.
+      # Map of ad id => recorded impressions, for cap enforcement.
       #
       def impression_counts
         @store.snapshot.transform_values { |data| data[:impressions] }

--- a/lib/sponsored_logs/ledger/store/active_record.rb
+++ b/lib/sponsored_logs/ledger/store/active_record.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-require "digest"
-
 module SponsoredLogs
   module Ledger
     module Store
-      # Persistent store backed by ActiveRecord, one row per ad keyed by a
-      # SHA256 digest of the ad text (the full text is stored alongside for
-      # reporting). Rows live in `sponsored_logs_impressions`; run the
+      # Persistent store backed by ActiveRecord, one row per ad keyed by the
+      # stable ad id (the full text is stored alongside for reporting). For an
+      # ad with no explicit id the id defaults to SHA256(text), so the ad_id
+      # column holds exactly the digest the pre-0.4.0 text_digest column did.
+      # Rows live in `sponsored_logs_impressions`; run the
       # `sponsored_logs:install` generator to create the migration.
       #
       # ActiveRecord is required lazily, so it stays an optional dependency.
@@ -20,24 +20,25 @@ module SponsoredLogs
         end
 
         def record(ad)
-          digest = digest_for(ad[:text])
+          id = Identity.id_for(ad)
 
           # insert skips on conflict (INSERT ... ON CONFLICT DO NOTHING), so an
           # existing row keeps its impression count. Then atomically bump the
-          # counter and refresh cpm in a single UPDATE.
+          # counter and refresh cpm and text in a single UPDATE, so a stable id
+          # whose copy was edited shows the latest text (like the other stores).
           #
           @model.insert(
-            { text_digest: digest, text: ad[:text], cpm: ad[:cpm].to_f, impressions: 0 },
-            unique_by: :text_digest
+            { ad_id: id, text: ad[:text], cpm: ad[:cpm].to_f, impressions: 0 },
+            unique_by: :ad_id
           )
-          @model.where(text_digest: digest).update_all(
-            ["impressions = impressions + 1, cpm = ?", ad[:cpm].to_f]
+          @model.where(ad_id: id).update_all(
+            ["impressions = impressions + 1, cpm = ?, text = ?", ad[:cpm].to_f, ad[:text].to_s]
           )
         end
 
         def snapshot
           @model.all.to_h do |row|
-            [row.text, { impressions: row.impressions.to_i, cpm: row.cpm.to_f }]
+            [row.ad_id, { text: row.text, impressions: row.impressions.to_i, cpm: row.cpm.to_f }]
           end
         end
 
@@ -47,10 +48,6 @@ module SponsoredLogs
         end
 
         private
-
-        def digest_for(text)
-          Digest::SHA256.hexdigest(text.to_s)
-        end
 
         # Defined lazily so requiring this file never needs ActiveRecord loaded.
         #

--- a/lib/sponsored_logs/ledger/store/base.rb
+++ b/lib/sponsored_logs/ledger/store/base.rb
@@ -12,14 +12,18 @@ module SponsoredLogs
       #
       class Base
         # Record a single impression for the given normalized ad hash
-        # ({ text:, weight:, cpm: }). Called once per emitted message.
+        # ({ id:, text:, weight:, cpm: }). Called once per emitted message.
+        # Tallies are keyed by the stable ad id (SponsoredLogs::Advertisers
+        # Identity.id_for), not the mutable text, so editing copy never resets
+        # a count.
         #
         def record(_ad)
           raise NotImplementedError, "#{self.class}#record must be implemented"
         end
 
-        # Return the current tallies as { text => { impressions: Integer,
-        # cpm: Float } }. The ledger derives everything else from this.
+        # Return the current tallies as { id => { text: String, impressions:
+        # Integer, cpm: Float } }. Text is a display value here, not the key;
+        # the ledger derives everything else from this.
         #
         def snapshot
           raise NotImplementedError, "#{self.class}#snapshot must be implemented"

--- a/lib/sponsored_logs/ledger/store/memory.rb
+++ b/lib/sponsored_logs/ledger/store/memory.rb
@@ -3,9 +3,10 @@
 module SponsoredLogs
   module Ledger
     module Store
-      # Default adapter. Keeps impression counts and CPMs in memory, keyed by ad
-      # text. Not persisted across process restarts. A mutex guards writes so the
-      # periodic thread and request threads can record concurrently.
+      # Default adapter. Keeps impression counts and CPMs in memory, keyed by the
+      # stable ad id (text stored alongside for display). Not persisted across
+      # process restarts. A mutex guards writes so the periodic thread and
+      # request threads can record concurrently.
       #
       class Memory < Base
         def initialize
@@ -13,19 +14,23 @@ module SponsoredLogs
           @mutex = Mutex.new
           @impressions = Hash.new(0)
           @cpm = {}
+          @text = {}
         end
 
         def record(ad)
+          id = Identity.id_for(ad)
+
           @mutex.synchronize do
-            @impressions[ad[:text]] += 1
-            @cpm[ad[:text]] = ad[:cpm].to_f
+            @impressions[id] += 1
+            @cpm[id] = ad[:cpm].to_f
+            @text[id] = ad[:text].to_s
           end
         end
 
         def snapshot
           @mutex.synchronize do
-            @impressions.each_with_object({}) do |(text, count), acc|
-              acc[text] = { impressions: count, cpm: @cpm[text].to_f }
+            @impressions.each_with_object({}) do |(id, count), acc|
+              acc[id] = { text: @text[id], impressions: count, cpm: @cpm[id].to_f }
             end
           end
         end
@@ -34,6 +39,7 @@ module SponsoredLogs
           @mutex.synchronize do
             @impressions = Hash.new(0)
             @cpm = {}
+            @text = {}
           end
           self
         end

--- a/lib/sponsored_logs/ledger/store/redis.rb
+++ b/lib/sponsored_logs/ledger/store/redis.rb
@@ -11,24 +11,28 @@ module SponsoredLogs
           @client = client || build_default_client
           @impressions_key = "#{namespace}:impressions"
           @cpm_key = "#{namespace}:cpm"
+          @text_key = "#{namespace}:text"
         end
 
         def record(ad)
-          @client.hincrby(@impressions_key, ad[:text], 1)
-          @client.hset(@cpm_key, ad[:text], ad[:cpm].to_f)
+          id = Identity.id_for(ad)
+          @client.hincrby(@impressions_key, id, 1)
+          @client.hset(@cpm_key, id, ad[:cpm].to_f)
+          @client.hset(@text_key, id, ad[:text].to_s)
         end
 
         def snapshot
           impressions = @client.hgetall(@impressions_key)
           cpm = @client.hgetall(@cpm_key)
+          text = @client.hgetall(@text_key)
 
-          impressions.each_with_object({}) do |(text, count), acc|
-            acc[text] = { impressions: count.to_i, cpm: cpm[text].to_f }
+          impressions.each_with_object({}) do |(id, count), acc|
+            acc[id] = { text: text[id], impressions: count.to_i, cpm: cpm[id].to_f }
           end
         end
 
         def reset
-          @client.del(@impressions_key, @cpm_key)
+          @client.del(@impressions_key, @cpm_key, @text_key)
           self
         end
 

--- a/spec/ledger_store_active_record_spec.rb
+++ b/spec/ledger_store_active_record_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "active_record"
+require "digest"
 require "tmpdir"
 
 RSpec.describe SponsoredLogs::Ledger::Store::ActiveRecord do
@@ -13,13 +14,13 @@ RSpec.describe SponsoredLogs::Ledger::Store::ActiveRecord do
     ActiveRecord::Schema.verbose = false
     ActiveRecord::Schema.define do
       create_table :sponsored_logs_impressions, force: true do |t|
-        t.string  :text_digest, null: false
+        t.string  :ad_id,       null: false
         t.text    :text,        null: false
         t.integer :impressions, null: false, default: 0
         t.float   :cpm,         null: false, default: 0.0
         t.timestamps
       end
-      add_index :sponsored_logs_impressions, :text_digest, unique: true
+      add_index :sponsored_logs_impressions, :ad_id, unique: true
     end
   end
 
@@ -32,26 +33,42 @@ RSpec.describe SponsoredLogs::Ledger::Store::ActiveRecord do
 
   after { store.reset }
 
-  it "records impressions and cpm, keyed by text" do
-    2.times { store.record(text: "a", weight: 1, cpm: 10.0) }
-    store.record(text: "b", weight: 1, cpm: 5.0)
+  it "records impressions and cpm, keyed by id with text as a value", :aggregate_failures do
+    2.times { store.record(id: "a", text: "Ad A", weight: 1, cpm: 10.0) }
+    store.record(id: "b", text: "Ad B", weight: 1, cpm: 5.0)
 
     expect(store.snapshot).to eq(
-      "a" => { impressions: 2, cpm: 10.0 },
-      "b" => { impressions: 1, cpm: 5.0 }
+      "a" => { text: "Ad A", impressions: 2, cpm: 10.0 },
+      "b" => { text: "Ad B", impressions: 1, cpm: 5.0 }
     )
   end
 
+  it "defaults a no-id ad's ad_id to SHA256(text), matching the old digest key", :aggregate_failures do
+    store.record(text: "legacy copy", weight: 1, cpm: 4.0)
+
+    digest = Digest::SHA256.hexdigest("legacy copy")
+    expect(store.snapshot.keys).to eq([digest])
+    expect(store.snapshot[digest]).to eq(text: "legacy copy", impressions: 1, cpm: 4.0)
+  end
+
+  it "keeps one tally for a stable id across a copy edit", :aggregate_failures do
+    store.record(id: "promo", text: "v1", weight: 1, cpm: 6.0)
+    store.record(id: "promo", text: "v2 edited", weight: 1, cpm: 6.0)
+
+    expect(store.snapshot.keys).to eq(["promo"])
+    expect(store.snapshot["promo"]).to eq(text: "v2 edited", impressions: 2, cpm: 6.0)
+  end
+
   it "persists across store instances (same table)", :aggregate_failures do
-    described_class.new.record(text: "persisted", weight: 1, cpm: 7.0)
+    described_class.new.record(id: "persisted", text: "Persisted", weight: 1, cpm: 7.0)
 
     fresh = described_class.new
-    expect(fresh.snapshot["persisted"]).to eq(impressions: 1, cpm: 7.0)
+    expect(fresh.snapshot["persisted"]).to eq(text: "Persisted", impressions: 1, cpm: 7.0)
   end
 
   it "increments atomically under concurrency" do
     threads = Array.new(5) do
-      Thread.new { 20.times { described_class.new.record(text: "hot", weight: 1, cpm: 1.0) } }
+      Thread.new { 20.times { described_class.new.record(id: "hot", text: "Hot", weight: 1, cpm: 1.0) } }
     end
     threads.each(&:join)
 
@@ -59,15 +76,15 @@ RSpec.describe SponsoredLogs::Ledger::Store::ActiveRecord do
   end
 
   it "reset clears the rows" do
-    store.record(text: "a", weight: 1, cpm: 10.0)
+    store.record(id: "a", text: "Ad A", weight: 1, cpm: 10.0)
     store.reset
     expect(store.snapshot).to eq({})
   end
 
-  it "handles long ad text via the digest key" do
+  it "handles long ad text via the id key" do
     long = "Sponsored by #{"x" * 5000}"
-    store.record(text: long, weight: 1, cpm: 3.0)
+    store.record(id: "long", text: long, weight: 1, cpm: 3.0)
 
-    expect(store.snapshot[long]).to eq(impressions: 1, cpm: 3.0)
+    expect(store.snapshot["long"]).to eq(text: long, impressions: 1, cpm: 3.0)
   end
 end

--- a/spec/ledger_store_spec.rb
+++ b/spec/ledger_store_spec.rb
@@ -12,25 +12,25 @@ end
 RSpec.describe SponsoredLogs::Ledger::Store::Memory do
   let(:store) { described_class.new }
 
-  it "records impressions and cpm, keyed by text" do
-    2.times { store.record(text: "a", weight: 1, cpm: 10.0) }
-    store.record(text: "b", weight: 1, cpm: 5.0)
+  it "records impressions and cpm, keyed by id with text as a value", :aggregate_failures do
+    2.times { store.record(id: "a", text: "Ad A", weight: 1, cpm: 10.0) }
+    store.record(id: "b", text: "Ad B", weight: 1, cpm: 5.0)
 
     expect(store.snapshot).to eq(
-      "a" => { impressions: 2, cpm: 10.0 },
-      "b" => { impressions: 1, cpm: 5.0 }
+      "a" => { text: "Ad A", impressions: 2, cpm: 10.0 },
+      "b" => { text: "Ad B", impressions: 1, cpm: 5.0 }
     )
   end
 
   it "reset clears the snapshot" do
-    store.record(text: "a", weight: 1, cpm: 10.0)
+    store.record(id: "a", text: "Ad A", weight: 1, cpm: 10.0)
     store.reset
     expect(store.snapshot).to eq({})
   end
 
   it "records concurrently without losing increments" do
     threads = Array.new(10) do
-      Thread.new { 100.times { store.record(text: "a", weight: 1, cpm: 1.0) } }
+      Thread.new { 100.times { store.record(id: "a", text: "Ad A", weight: 1, cpm: 1.0) } }
     end
     threads.each(&:join)
 
@@ -68,18 +68,18 @@ RSpec.describe SponsoredLogs::Ledger::Store::Redis do
 
   let(:store) { described_class.new(client: fake_redis) }
 
-  it "records impressions and cpm via the client" do
-    2.times { store.record(text: "a", weight: 1, cpm: 10.0) }
-    store.record(text: "b", weight: 1, cpm: 5.0)
+  it "records impressions and cpm via the client, keyed by id", :aggregate_failures do
+    2.times { store.record(id: "a", text: "Ad A", weight: 1, cpm: 10.0) }
+    store.record(id: "b", text: "Ad B", weight: 1, cpm: 5.0)
 
     expect(store.snapshot).to eq(
-      "a" => { impressions: 2, cpm: 10.0 },
-      "b" => { impressions: 1, cpm: 5.0 }
+      "a" => { text: "Ad A", impressions: 2, cpm: 10.0 },
+      "b" => { text: "Ad B", impressions: 1, cpm: 5.0 }
     )
   end
 
   it "reset deletes the keys" do
-    store.record(text: "a", weight: 1, cpm: 10.0)
+    store.record(id: "a", text: "Ad A", weight: 1, cpm: 10.0)
     store.reset
     expect(store.snapshot).to eq({})
   end

--- a/spec/sponsored_logs_spec.rb
+++ b/spec/sponsored_logs_spec.rb
@@ -3,6 +3,7 @@
 require "stringio"
 require "logger"
 require "tempfile"
+require "digest"
 
 RSpec.describe SponsoredLogs do
   describe ".sponsor! and .unsponsor!" do
@@ -730,7 +731,9 @@ RSpec.describe SponsoredLogs do
         { text: "capped", weight: 5, cap: 10 },
         { text: "open", weight: 1 }
       ]
-      counts = { "capped" => 10 }
+      # Counts are keyed by ad id; a no-id ad's id is SHA256(text).
+      #
+      counts = { Digest::SHA256.hexdigest("capped") => 10 }
       results = Array.new(100) do
         SponsoredLogs::Advertisers.render(
           SponsoredLogs::Advertisers.pick(ads, now: now, counts: counts), ""
@@ -741,7 +744,8 @@ RSpec.describe SponsoredLogs do
 
     it "pick still allows an ad under its cap" do
       ads = [{ text: "capped", weight: 1, cap: 10 }]
-      picked = SponsoredLogs::Advertisers.pick(ads, now: now, counts: { "capped" => 9 })
+      counts = { Digest::SHA256.hexdigest("capped") => 9 }
+      picked = SponsoredLogs::Advertisers.pick(ads, now: now, counts: counts)
       expect(picked[:text]).to eq("capped")
     end
   end
@@ -828,7 +832,7 @@ RSpec.describe SponsoredLogs do
           .to receive(:paid_default_pool)
           .and_return([{ text: "capped", weight: 1, cap: 1 }])
 
-        picked = SponsoredLogs::Advertisers.pick(expired, now: now, counts: { "capped" => 5 })
+        picked = SponsoredLogs::Advertisers.pick(expired, now: now, counts: { Digest::SHA256.hexdigest("capped") => 5 })
         expect(picked).not_to be_nil
         expect(house_texts).to include(picked[:text])
         expect(picked[:advertiser]).to eq("SponsoredLogs")
@@ -869,7 +873,7 @@ RSpec.describe SponsoredLogs do
           .to receive(:paid_default_pool)
           .and_return([{ text: "capped", weight: 1, cap: 1 }])
 
-        picked = SponsoredLogs::Advertisers.pick(expired, now: now, counts: { "capped" => 5 })
+        picked = SponsoredLogs::Advertisers.pick(expired, now: now, counts: { Digest::SHA256.hexdigest("capped") => 5 })
         expect(picked).not_to be_nil
         expect(picked[:advertiser]).to eq("SponsoredLogs")
       end
@@ -901,16 +905,17 @@ RSpec.describe SponsoredLogs do
           .and_return([{ text: "capped", weight: 1, cap: 1 }])
 
         expect(
-          SponsoredLogs::Advertisers.pick(expired, now: now, counts: { "capped" => 5 })
+          SponsoredLogs::Advertisers.pick(expired, now: now, counts: { Digest::SHA256.hexdigest("capped") => 5 })
         ).to be_nil
       end
 
       it "still returns nil for an out-of-flight user pool" do
         expired = [{ text: "expired", weight: 1, ends_at: "2000-01-01" }]
-        counts = { "expired" => 0 }
-        # Every PAID default is also forced ineligible so only the floor could save it.
+        counts = { Digest::SHA256.hexdigest("expired") => 0 }
+        # Every PAID default is also forced ineligible so only the floor could
+        # save it. Counts are keyed by ad id (SHA256(text) for these no-id ads).
         #
-        paid_counts = SponsoredLogs::Advertisers::PAID_ADS.to_h { |ad| [ad[:text], 1_000_000] }
+        paid_counts = SponsoredLogs::Advertisers::PAID_ADS.to_h { |ad| [Digest::SHA256.hexdigest(ad[:text]), 1_000_000] }
         capped_pool = SponsoredLogs::Advertisers::PAID_ADS.map { |ad| ad.merge(cap: 1) }
         allow(SponsoredLogs::Advertisers).to receive(:paid_default_pool).and_return(capped_pool)
 

--- a/spec/stable_ad_identity_spec.rb
+++ b/spec/stable_ad_identity_spec.rb
@@ -1,0 +1,198 @@
+# frozen_string_literal: true
+
+require "digest"
+
+# Stable ad identity: the ledger keys impressions on an immutable ad `id`
+# instead of the mutable ad text. Ads without an explicit id fall back to
+# SHA256(text), which is byte-compatible with the pre-0.4.0 text-keyed
+# behavior. Explicit ids give advertisers stable tallies across copy edits.
+#
+RSpec.describe "stable ad identity" do
+  def sha(text)
+    Digest::SHA256.hexdigest(text)
+  end
+
+  describe "SponsoredLogs::Advertisers.normalize id" do
+    it "defaults id to SHA256(text) when no id is given" do
+      ad = SponsoredLogs::Advertisers.normalize([{ text: "hello" }]).first
+      expect(ad[:id]).to eq(sha("hello"))
+    end
+
+    it "uses an explicit id when present" do
+      ad = SponsoredLogs::Advertisers.normalize([{ text: "hello", id: "promo-42" }]).first
+      expect(ad[:id]).to eq("promo-42")
+    end
+
+    it "accepts a string id key from parsed JSON" do
+      ad = SponsoredLogs::Advertisers.normalize([{ "text" => "hi", "id" => "promo-7" }]).first
+      expect(ad[:id]).to eq("promo-7")
+    end
+
+    it "coerces a non-string id and strips surrounding whitespace" do
+      ad = SponsoredLogs::Advertisers.normalize([{ text: "hi", id: "  99 " }]).first
+      expect(ad[:id]).to eq("99")
+    end
+
+    it "falls back to the text hash when id is blank", :aggregate_failures do
+      blank = SponsoredLogs::Advertisers.normalize([{ text: "hi", id: "   " }]).first
+      empty = SponsoredLogs::Advertisers.normalize([{ text: "hi", id: "" }]).first
+      expect(blank[:id]).to eq(sha("hi"))
+      expect(empty[:id]).to eq(sha("hi"))
+    end
+  end
+
+  describe "identity semantics" do
+    let(:store) { SponsoredLogs::Ledger::Store::Memory.new }
+    let(:ledger) { SponsoredLogs::Ledger::Report.new(store) }
+
+    it "tallies identical copy under different explicit ids separately", :aggregate_failures do
+      a = SponsoredLogs::Advertisers.normalize([{ text: "same copy", id: "a" }]).first
+      b = SponsoredLogs::Advertisers.normalize([{ text: "same copy", id: "b" }]).first
+
+      3.times { ledger.record(a) }
+      ledger.record(b)
+
+      counts = ledger.impression_counts
+      expect(counts["a"]).to eq(3)
+      expect(counts["b"]).to eq(1)
+    end
+
+    it "preserves the tally when copy changes but the id is stable" do
+      original = SponsoredLogs::Advertisers.normalize([{ text: "v1 copy", id: "promo" }]).first
+      2.times { ledger.record(original) }
+
+      edited = SponsoredLogs::Advertisers.normalize([{ text: "v2 rewritten copy", id: "promo" }]).first
+      ledger.record(edited)
+
+      expect(ledger.impression_counts["promo"]).to eq(3)
+    end
+
+    it "keys a no-id ad by SHA256(text), matching the pre-0.4.0 behavior" do
+      ad = SponsoredLogs::Advertisers.normalize([{ text: "legacy" }]).first
+      ledger.record(ad)
+
+      expect(ledger.impression_counts.keys).to eq([sha("legacy")])
+    end
+
+    it "shows the latest text for a stable id in the snapshot value" do
+      original = SponsoredLogs::Advertisers.normalize([{ text: "old copy", id: "promo", cpm: 5.0 }]).first
+      ledger.record(original)
+      edited = SponsoredLogs::Advertisers.normalize([{ text: "new copy", id: "promo", cpm: 5.0 }]).first
+      ledger.record(edited)
+
+      expect(store.snapshot["promo"][:text]).to eq("new copy")
+    end
+  end
+
+  describe "cap enforcement keys on id consistently" do
+    it "enforces the cap by id: record-key == impression_counts-key == eligible-key", :aggregate_failures do
+      now = Time.now
+      store = SponsoredLogs::Ledger::Store::Memory.new
+      ledger = SponsoredLogs::Ledger::Report.new(store)
+
+      # Capped at 2. Record it twice through the same normalized identity, then
+      # confirm the cap lookup (by id) agrees and pick refuses to serve it.
+      #
+      ad = SponsoredLogs::Advertisers.normalize([{ text: "capped copy", id: "cap-1", cap: 2 }]).first
+      2.times { ledger.record(ad) }
+
+      counts = ledger.impression_counts
+      expect(counts.keys).to eq(["cap-1"])
+      expect(counts["cap-1"]).to eq(2)
+
+      # The id the ledger stored under is the same id eligible looks up, so the
+      # cap fires: the capped creative is excluded from the eligible set.
+      #
+      pool = SponsoredLogs::Advertisers.normalize([{ text: "capped copy", id: "cap-1", cap: 2 }])
+      eligible = SponsoredLogs::Advertisers.eligible(pool, now, counts)
+      expect(eligible).to be_empty
+    end
+
+    it "still serves an ad under its cap when counts are keyed by id" do
+      now = Time.now
+      picked = SponsoredLogs::Advertisers.pick(
+        [{ text: "capped copy", id: "cap-2", cap: 10 }],
+        now: now, counts: { "cap-2" => 9 }
+      )
+      expect(picked[:id]).to eq("cap-2")
+    end
+  end
+
+  describe "each store keys by id and carries text in the snapshot" do
+    shared_examples "an id-keyed store" do
+      it "keys the snapshot by id and stores text as a value", :aggregate_failures do
+        ad = { id: "promo", text: "the copy", weight: 1, cpm: 8.0 }
+        2.times { store.record(ad) }
+
+        snap = store.snapshot
+        expect(snap.keys).to eq(["promo"])
+        expect(snap["promo"]).to eq(text: "the copy", impressions: 2, cpm: 8.0)
+      end
+
+      it "falls back to SHA256(text) for an ad with no id", :aggregate_failures do
+        store.record(text: "no id here", weight: 1, cpm: 3.0)
+
+        snap = store.snapshot
+        expect(snap.keys).to eq([sha("no id here")])
+        expect(snap[sha("no id here")][:text]).to eq("no id here")
+      end
+    end
+
+    describe SponsoredLogs::Ledger::Store::Memory do
+      let(:store) { described_class.new }
+      it_behaves_like "an id-keyed store"
+    end
+
+    describe SponsoredLogs::Ledger::Store::Redis do
+      let(:fake_redis) do
+        Class.new do
+          def initialize
+            @hashes = Hash.new { |h, k| h[k] = {} }
+          end
+
+          def hincrby(key, field, by)
+            @hashes[key][field] = @hashes[key].fetch(field, 0).to_i + by
+          end
+
+          def hset(key, field, value)
+            @hashes[key][field] = value.to_s
+          end
+
+          def hgetall(key)
+            @hashes[key].transform_values(&:to_s)
+          end
+
+          def del(*keys)
+            keys.each { |k| @hashes.delete(k) }
+          end
+        end.new
+      end
+
+      let(:store) { described_class.new(client: fake_redis) }
+      it_behaves_like "an id-keyed store"
+    end
+  end
+
+  describe "house-ad identification by id" do
+    it "computes HOUSE_IDS as the text hashes of the built-in house ads" do
+      expected = SponsoredLogs::Advertisers::HOUSE_ADS.map { |ad| sha(ad[:text]) }
+      expect(SponsoredLogs::Advertisers::HOUSE_IDS).to eq(expected)
+    end
+
+    it "drops house ads by id even after their copy is edited", :aggregate_failures do
+      allow(SponsoredLogs.configuration).to receive(:house_ads).and_return(false)
+
+      # A house ad whose TEXT was edited but whose id still resolves to the
+      # original house id (explicit id set to the house id).
+      #
+      house = SponsoredLogs::Advertisers::HOUSE_ADS.first
+      house_id = sha(house[:text])
+      edited_house = { id: house_id, text: "edited house copy", weight: 1, cpm: 0.0 }
+      paid = { id: "paid-1", text: "paid copy", weight: 1, cpm: 10.0 }
+
+      filtered = SponsoredLogs::Advertisers.drop_house([edited_house, paid])
+      expect(filtered.map { |ad| ad[:id] }).to eq(["paid-1"])
+      expect(filtered).not_to include(edited_house)
+    end
+  end
+end


### PR DESCRIPTION
🪪📈 **Identity is a moat. Copy is a draft, not an account.** 📈🪪

An advertiser that rewrites its line is not a new advertiser — but the ledger used to think so. Impressions, spend, and cap were keyed by ad text, so editing a single character silently reset the book and two advertisers running the same line collided into one tally. Fixed.

## 🪙 What changed

- **Every ad gets an optional `id`.** Set it and the account rides through a mid-flight copy rewrite — impressions, spend, cap, all intact. 🎯
- **Omit it and nothing moves.** `id` falls back to a content hash of the text — exactly how the ledger has always keyed — so existing books are byte-for-byte unchanged. Back-compat is automatic.
- **Two advertisers, one line, separate books.** Identical copy no longer collides when the ids differ.
- **The ledger settles by account, not by copy.** Snapshot is now `{ id => {text:, impressions:, cpm:} }` — text rides along as a label so the Command Center still reads in plain English; caps and reporting key on `id` end to end.
- **`text_digest` retires; `ad_id` takes the desk.** 🗄️ The ActiveRecord ledger keys on `ad_id`, which for a no-id ad is exactly the old digest, so existing rows line up untouched. Redis tallies reset once on upgrade.

## 🔬 Diligence

- 🧪 **230 examples, 0 failures** (+19), failing-first. Cap consistency is architecturally guaranteed: record, `eligible`, and `impression_counts` all key through one `Identity.id_for` — a spec fails if they ever diverge.
- 🧹 RuboCop clean, no disables. New `Identity` module for cohesion.
- 👀 Reviewed and approved.
- ⚠️ **Breaking for custom stores** (the documented snapshot shape changed) → this ships as **0.4.0**. Existing ActiveRecord installs rerun `rails g sponsored_logs:install` (or rename the column + its unique index).

An advertiser should never have to re-earn its own history just to fix a typo. 🌊
