### PR TITLE
Release v0.4.0: stable ad identity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-09-10
+
 ### Added
 
 - **Identity is a moat.** Copy is a draft, not an account — an advertiser that rewrites its line is not a new advertiser. Every ad takes an optional `id`; set it and impressions, spend, and cap ride through a mid-flight rewrite, omit it and `id` falls back to a content hash of the text so nothing already booked moves. Two advertisers can even run the same line as separate books. Works in the JSON ads file
@@ -87,7 +89,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Requires Ruby >= 3.1
 
-[Unreleased]: https://github.com/sponsoredlogs/sponsored_logs/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/sponsoredlogs/sponsored_logs/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/sponsoredlogs/sponsored_logs/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/sponsoredlogs/sponsored_logs/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/sponsoredlogs/sponsored_logs/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/sponsoredlogs/sponsored_logs/compare/v0.1.0...v0.2.0

--- a/lib/sponsored_logs/version.rb
+++ b/lib/sponsored_logs/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SponsoredLogs
-  VERSION = "0.3.1"
+  VERSION = "0.4.0"
 end


### PR DESCRIPTION
🪪📈 **v0.4.0 — stable ad identity.** 📈🪪

Copy is a draft, not an account. The ledger now settles by a stable ad `id` instead of by ad text — so editing a line no longer resets its book, and two advertisers running the same copy no longer collide into one tally.

- 🪙 Optional `id:` per ad → impressions, spend, and cap ride through a mid-flight rewrite. Omit it and `id` falls back to a content hash of the text, so existing books are byte-for-byte unchanged.
- 📒 New snapshot contract `{ id => {text:, impressions:, cpm:} }` — text rides along as a label, the Command Center still reads in plain English, caps and reporting key on `id` end to end.
- 🗄️ ActiveRecord ledger keys on `ad_id` (== the old digest for no-id ads, so rows line up); existing installs rerun `rails g sponsored_logs:install`. Redis tallies reset once on upgrade.

🔖 `VERSION` → **0.4.0** (minor — the store snapshot contract changed, breaking for custom stores). Dated `## [0.4.0]` section + compare links updated. **230 examples, 0 failures.**

**After merge:** tag `v0.4.0`, GitHub Release, push to RubyGems. Governance is a feature. 🌊
