### PR TITLE
Activate the page as a second ad surface

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -21,13 +21,15 @@ Metrics/MethodLength:
 
 # The main module carries the full public API plus report-building helpers;
 # it is cohesive rather than bloated. The view helper grows with each chart.
+# The HTML-comment ad surface (render_html_comment/maybe_html_comment) added
+# public API here, so the ceiling tracks that growth.
 Metrics/ModuleLength:
-  Max: 160
+  Max: 165
   Exclude:
     - "lib/sponsored_logs/report/app/helpers/**/*"
 
 Metrics/ClassLength:
-  Max: 160
+  Max: 165
 
 Metrics/AbcSize:
   Max: 32

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The page is inventory now.** For too long the exchange sold one surface: log lines. HTML responses now carry host-read `[AD]` placements in their comment layer (`<!-- [AD] ... -->`), drawing from the same campaigns and settling to the same ledger as your logs. One book of business, two surfaces. New `html_probability` config (default `0.05`, its own dial because a page render is a rarer, higher-value event than a per-line log impression) and `SPONSORED_LOGS_HTML_PROBABILITY` env var; in Rails the controller surface wires itself on and stays dark until sponsoring is active. Brand safety holds: a crafted creative can't break out of its comment and into live markup, since every `--` run is defused so no placement escapes its slot. This is tier 1, the page; the per-component surface is next ([#23](https://github.com/sponsoredlogs/sponsored_logs/pull/23))
+
 ## [0.4.0] - 2026-09-10
 
 ### Added

--- a/lib/sponsored_logs.rb
+++ b/lib/sponsored_logs.rb
@@ -16,6 +16,7 @@ require_relative "sponsored_logs/ledger/store/active_record"
 require_relative "sponsored_logs/ledger/report"
 require_relative "sponsored_logs/configuration"
 require_relative "sponsored_logs/injector"
+require_relative "sponsored_logs/html_comment"
 require_relative "sponsored_logs/env"
 
 module SponsoredLogs
@@ -95,6 +96,24 @@ module SponsoredLogs
       end
 
       line
+    end
+
+    # HTML analog of maybe_emit, gated by its own html_probability knob because
+    # page renders are rarer than per-puts log lines.
+    #
+    def maybe_html_comment
+      return unless active?
+      return unless rand < configuration.html_probability
+
+      render_html_comment
+    end
+
+    # Pick, record, and wrap one ad as a hardened HTML comment (nil when none is
+    # eligible). Delegates to the shared HtmlComment core so the controller
+    # patch and, later, the partial hook reuse one path and one ledger.
+    #
+    def render_html_comment
+      HtmlComment.render(configuration, ledger)
     end
 
     # Rebuilt when the configured store changes, so swapping the store via

--- a/lib/sponsored_logs/configuration.rb
+++ b/lib/sponsored_logs/configuration.rb
@@ -2,8 +2,8 @@
 
 module SponsoredLogs
   class Configuration
-    attr_accessor :probability, :periodic, :interval, :output, :ad_prefix, :ads, :selection, :store, :report_page,
-                  :ascii_only, :house_ads
+    attr_accessor :probability, :html_probability, :periodic, :interval, :output, :ad_prefix, :ads, :selection, :store,
+                  :report_page, :ascii_only, :house_ads
     attr_reader :color
 
     # Gilding modes for the [AD] prefix. :auto gilds only on a NO_COLOR-clear
@@ -14,12 +14,13 @@ module SponsoredLogs
     # Settings that map 1:1 onto an accessor. ads/ads_file are handled
     # separately because they interact (ads wins; ads_file loads into ads).
     #
-    DIRECT_KEYS = %i[probability periodic interval output ad_prefix selection store report_page ascii_only
-                     house_ads color].freeze
+    DIRECT_KEYS = %i[probability html_probability periodic interval output ad_prefix selection store report_page
+                     ascii_only house_ads color].freeze
     KNOWN_KEYS = (DIRECT_KEYS + %i[ads ads_file]).freeze
 
     def initialize
       @probability = 0.001
+      @html_probability = 0.05
       @periodic = false
       @interval = 30
       @output = $stdout

--- a/lib/sponsored_logs/controller_patch.rb
+++ b/lib/sponsored_logs/controller_patch.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module SponsoredLogs
+  # Tier 1 of HTML-comment ads: append a host-read [AD] comment to the tail of
+  # an HTML controller response. Prepended onto the controller dispatch path so
+  # it runs after the action has built its response. Like the log Injector, a
+  # prepend can't be undone, so SponsoredLogs.active? (via maybe_html_comment)
+  # is what actually gates emission; install! just wires the prepend once.
+  #
+  module ControllerPatch
+    module RenderPatch
+      def dispatch(*, **)
+        result = super
+        SponsoredLogs::ControllerPatch.decorate(response)
+        result
+      end
+    end
+
+    # Append a comment to the response body when the response is HTML. Gating
+    # (active? + html_probability roll) lives in maybe_html_comment, so a nil
+    # return there means "no placement" and we leave the body untouched. The
+    # comment is appended after the existing body (after </html>): the
+    # deliberate low-risk trailing-append placement for this PR.
+    #
+    def self.decorate(response)
+      return unless response
+      return unless html_response?(response)
+
+      comment = SponsoredLogs.maybe_html_comment
+      return if comment.nil?
+
+      response.body = "#{response.body}#{comment}"
+    rescue StandardError
+      # Ad delivery must never break the host response; swallow and move on.
+      #
+      nil
+    end
+
+    # True when the response advertises an HTML media type. Guarded because not
+    # every response object exposes media_type/content_type cleanly.
+    #
+    def self.html_response?(response)
+      media = response.media_type if response.respond_to?(:media_type)
+      media ||= response.content_type if response.respond_to?(:content_type)
+      media.to_s.include?("text/html")
+    end
+
+    def self.install!
+      return if @installed
+      return unless defined?(ActionController::Metal)
+
+      ActionController::Metal.prepend(RenderPatch)
+      @installed = true
+    end
+
+    def self.installed?
+      @installed == true
+    end
+  end
+end

--- a/lib/sponsored_logs/env.rb
+++ b/lib/sponsored_logs/env.rb
@@ -14,6 +14,7 @@ module SponsoredLogs
     #
     OPTION_MAP = {
       "SPONSORED_LOGS_PROBABILITY" => [:probability, ->(v) { Float(v) }],
+      "SPONSORED_LOGS_HTML_PROBABILITY" => [:html_probability, ->(v) { Float(v) }],
       "SPONSORED_LOGS_INTERVAL" => [:interval, ->(v) { Float(v) }],
       "SPONSORED_LOGS_PERIODIC" => [:periodic, ->(v) { truthy?(v) }],
       "SPONSORED_LOGS_PREFIX" => [:ad_prefix, ->(v) { v }],

--- a/lib/sponsored_logs/html_comment.rb
+++ b/lib/sponsored_logs/html_comment.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module SponsoredLogs
+  # Shared, framework-agnostic core for HTML-comment ad placements. Picks an ad
+  # (reusing Advertisers.pick), records the impression to the same ledger as the
+  # log emitter, and wraps the copy as a hardened HTML comment. The controller
+  # render patch (and, in a later PR, a per-partial hook) both route through
+  # here, so every surface draws from the same campaigns and one ledger.
+  #
+  module HtmlComment
+    module_function
+
+    # Pick one ad, record the impression, and return it wrapped as an HTML
+    # comment: "<!-- [AD] <text> -->". Returns nil when no ad is eligible. No
+    # ANSI color: it is meaningless in HTML source, so the copy stays plain.
+    #
+    def render(config, ledger)
+      ad = Advertisers.pick(
+        config.ads,
+        mode: config.selection,
+        counts: ledger.impression_counts
+      )
+      return if ad.nil?
+
+      ledger.record(ad)
+
+      prefix = config.ad_prefix.to_s.strip
+      body = prefix.empty? ? ad[:text] : "#{prefix} #{ad[:text]}"
+      "<!-- #{escape(body)} -->"
+    end
+
+    # Neutralize the HTML comment delimiter so crafted ad copy cannot close the
+    # comment early and break out into live markup (comment-injection). Any "--"
+    # run is defused by inserting a zero-width space between the hyphens, which
+    # also covers "-->" as a special case. "--" inside a comment is invalid HTML
+    # anyway, so this both hardens against injection and yields a well-formed
+    # comment. The break is zero-width, so View Source reads normally.
+    #
+    def escape(text)
+      text.to_s.gsub(/-(?=-)/, "-\u200B")
+    end
+  end
+end

--- a/lib/sponsored_logs/railtie.rb
+++ b/lib/sponsored_logs/railtie.rb
@@ -2,6 +2,8 @@
 
 require "rails/railtie"
 
+require_relative "controller_patch"
+
 module SponsoredLogs
   class Railtie < Rails::Railtie
     initializer "sponsored_logs.sponsor_from_env" do
@@ -11,6 +13,18 @@ module SponsoredLogs
         opts = Env.options
         opts[:output] ||= Rails.logger if Rails.respond_to?(:logger) && Rails.logger
         SponsoredLogs.sponsor!(opts)
+      end
+    end
+
+    # Wire the controller render patch onto ActionController once it has loaded.
+    # The prepend is inert until sponsoring is active (runtime gating lives in
+    # maybe_html_comment via active?), so installing it here is safe even when
+    # the host never turns sponsoring on. This is the HTML-page analog of how
+    # Injector.install! wires the log patches.
+    #
+    initializer "sponsored_logs.controller_patch" do
+      ActiveSupport.on_load(:action_controller) do
+        SponsoredLogs::ControllerPatch.install!
       end
     end
   end

--- a/spec/controller_patch_spec.rb
+++ b/spec/controller_patch_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require "rails"
+require "action_controller"
+require "action_controller/metal"
+
+require "sponsored_logs/controller_patch"
+
+# Rails permits only one Rails::Application#initialize! per process (engine_spec
+# owns that boot), so we deliberately avoid booting an app here. Instead we
+# exercise the patched dispatch path directly: ActionController::Metal.action
+# returns a Rack endpoint we can call with a minimal env, giving us a genuine
+# ActionController response (real media_type, real body) without a host app.
+#
+RSpec.describe SponsoredLogs::ControllerPatch do
+  before(:all) do
+    SponsoredLogs::ControllerPatch.install!
+  end
+
+  # Minimal controllers built on Metal so .action works without routing/app.
+  #
+  html_controller = Class.new(ActionController::Metal) do
+    include AbstractController::Rendering
+    include ActionController::Rendering
+
+    def show
+      self.content_type = "text/html; charset=utf-8"
+      self.response_body = "<html><body>Hello</body></html>"
+    end
+  end
+
+  json_controller = Class.new(ActionController::Metal) do
+    def data
+      self.content_type = "application/json"
+      self.response_body = '{"ok":true}'
+    end
+  end
+
+  def call(controller, action)
+    env = Rack::MockRequest.env_for("/")
+    status, headers, body = controller.action(action).call(env)
+    joined = +""
+    body.each { |chunk| joined << chunk }
+    [status, headers, joined]
+  end
+
+  it "appends an ad comment to an HTML response when active", :aggregate_failures do
+    SponsoredLogs.sponsor!(html_probability: 1.0, ads: [{ text: "Trailing ad", weight: 1 }])
+
+    _status, _headers, body = call(html_controller, :show)
+
+    expect(body).to include("<!-- [AD] Trailing ad -->")
+    # Comment lands after the closing html tag (trailing append, this PR).
+    #
+    expect(body).to match(%r{</html>.*<!-- \[AD\] Trailing ad -->}m)
+  end
+
+  it "does not touch a non-HTML response", :aggregate_failures do
+    SponsoredLogs.sponsor!(html_probability: 1.0, ads: [{ text: "Trailing ad", weight: 1 }])
+
+    _status, _headers, body = call(json_controller, :data)
+
+    expect(body).to eq('{"ok":true}')
+    expect(body).not_to include("[AD]")
+  end
+
+  it "stays silent when sponsoring is inactive" do
+    SponsoredLogs.unsponsor!
+
+    _status, _headers, body = call(html_controller, :show)
+
+    expect(body).not_to include("[AD]")
+  end
+
+  it "respects html_probability of zero" do
+    SponsoredLogs.sponsor!(html_probability: 0.0, ads: [{ text: "Trailing ad", weight: 1 }])
+
+    _status, _headers, body = call(html_controller, :show)
+
+    expect(body).not_to include("[AD]")
+  end
+
+  it "leaves the original HTML intact ahead of the comment" do
+    SponsoredLogs.sponsor!(html_probability: 1.0, ads: [{ text: "Trailing ad", weight: 1 }])
+
+    _status, _headers, body = call(html_controller, :show)
+
+    expect(body).to include("<html><body>Hello</body></html>")
+  end
+end

--- a/spec/env_spec.rb
+++ b/spec/env_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe SponsoredLogs::Env do
     it "parses each supported override", :aggregate_failures do
       env = {
         "SPONSORED_LOGS_PROBABILITY" => "0.25",
+        "SPONSORED_LOGS_HTML_PROBABILITY" => "0.75",
         "SPONSORED_LOGS_INTERVAL" => "15",
         "SPONSORED_LOGS_PERIODIC" => "true",
         "SPONSORED_LOGS_PREFIX" => "SPONSORED:",
@@ -31,6 +32,7 @@ RSpec.describe SponsoredLogs::Env do
 
       expect(described_class.options(env)).to eq(
         probability: 0.25,
+        html_probability: 0.75,
         interval: 15.0,
         periodic: true,
         ad_prefix: "SPONSORED:",

--- a/spec/html_comment_spec.rb
+++ b/spec/html_comment_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+require "stringio"
+
+RSpec.describe SponsoredLogs do
+  describe "html_probability configuration" do
+    it "defaults to 0.05" do
+      expect(described_class.configuration.html_probability).to eq(0.05)
+    end
+
+    it "is applied via sponsor!/assign", :aggregate_failures do
+      described_class.sponsor!(html_probability: 0.5)
+
+      expect(described_class.configuration.html_probability).to eq(0.5)
+    end
+
+    it "accepts string keys through assign" do
+      config = SponsoredLogs::Configuration.new
+      config.assign({ "html_probability" => 0.6 }, warn_to: StringIO.new)
+
+      expect(config.html_probability).to eq(0.6)
+    end
+
+    it "is separate from probability", :aggregate_failures do
+      described_class.sponsor!(probability: 0.2, html_probability: 0.9)
+
+      expect(described_class.configuration.probability).to eq(0.2)
+      expect(described_class.configuration.html_probability).to eq(0.9)
+    end
+  end
+
+  describe ".render_html_comment" do
+    it "wraps the picked ad text as an HTML comment", :aggregate_failures do
+      described_class.sponsor!(ads: [{ text: "Buy widgets now", weight: 1 }])
+
+      comment = described_class.render_html_comment
+
+      expect(comment).to start_with("<!-- [AD] ")
+      expect(comment).to end_with(" -->")
+      expect(comment).to include("Buy widgets now")
+    end
+
+    it "uses the configured ad_prefix" do
+      described_class.sponsor!(ad_prefix: "SPONSORED:", ads: [{ text: "Copy here", weight: 1 }])
+
+      expect(described_class.render_html_comment).to eq("<!-- SPONSORED: Copy here -->")
+    end
+
+    it "records the impression to the ledger", :aggregate_failures do
+      described_class.sponsor!(ads: [{ text: "Track me", weight: 1, cpm: 10.0 }])
+
+      expect { described_class.render_html_comment }
+        .to change { described_class.ledger.total_impressions }.by(1)
+    end
+
+    it "returns nil when no ad can be picked" do
+      described_class.sponsor!
+      allow(SponsoredLogs::Advertisers).to receive(:pick).and_return(nil)
+
+      expect(described_class.render_html_comment).to be_nil
+    end
+
+    it "does not record when no ad can be picked" do
+      described_class.sponsor!
+      allow(SponsoredLogs::Advertisers).to receive(:pick).and_return(nil)
+
+      expect { described_class.render_html_comment }
+        .not_to(change { described_class.ledger.total_impressions })
+    end
+
+    it "carries no ANSI color codes" do
+      described_class.sponsor!(ads: [{ text: "Plain text ad", weight: 1 }])
+
+      expect(described_class.render_html_comment).not_to match(/\e\[/)
+    end
+  end
+
+  describe ".render_html_comment delimiter hardening" do
+    it "neutralizes a closing comment delimiter in ad copy", :aggregate_failures do
+      described_class.sponsor!(ads: [{ text: "Legit --> <script>alert(1)</script>", weight: 1 }])
+
+      comment = described_class.render_html_comment
+
+      # The only closer is the real trailing one; the injected --> is broken.
+      #
+      expect(comment.scan("-->").length).to eq(1)
+      expect(comment).to end_with(" -->")
+      expect(comment).not_to include("--> <script>")
+    end
+
+    it "neutralizes bare double-hyphen sequences inside the comment" do
+      described_class.sponsor!(ads: [{ text: "a -- b -- c", weight: 1 }])
+
+      comment = described_class.render_html_comment
+      body = comment.delete_prefix("<!-- ").delete_suffix(" -->")
+
+      expect(body).not_to include("--")
+    end
+
+    it "still ends with exactly one valid closer for adversarial copy", :aggregate_failures do
+      described_class.sponsor!(ads: [{ text: "--> --> -->", weight: 1 }])
+
+      comment = described_class.render_html_comment
+
+      expect(comment.scan("-->").length).to eq(1)
+      expect(comment).to start_with("<!-- [AD] ")
+      expect(comment).to end_with(" -->")
+    end
+  end
+
+  describe SponsoredLogs::HtmlComment do
+    describe ".escape" do
+      it "leaves copy without hyphen runs untouched" do
+        expect(described_class.escape("plain copy")).to eq("plain copy")
+      end
+
+      it "breaks up every double-hyphen run", :aggregate_failures do
+        result = described_class.escape("a--b-->c")
+
+        expect(result).not_to include("--")
+        expect(result).not_to include("-->")
+      end
+    end
+  end
+
+  describe ".maybe_html_comment" do
+    it "returns nil when sponsoring is inactive" do
+      described_class.unsponsor!
+
+      expect(described_class.maybe_html_comment).to be_nil
+    end
+
+    it "emits when active and probability is 1.0", :aggregate_failures do
+      described_class.sponsor!(html_probability: 1.0, ads: [{ text: "Always on", weight: 1 }])
+
+      comment = described_class.maybe_html_comment
+
+      expect(comment).to include("Always on")
+      expect(comment).to start_with("<!-- ")
+    end
+
+    it "stays silent when html_probability is zero" do
+      described_class.sponsor!(html_probability: 0.0, ads: [{ text: "Never", weight: 1 }])
+
+      results = Array.new(100) { described_class.maybe_html_comment }
+
+      expect(results.compact).to be_empty
+    end
+
+    it "does not consult probability when inactive" do
+      described_class.unsponsor!
+      described_class.configuration.html_probability = 1.0
+
+      expect(described_class.maybe_html_comment).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
> 📄💰 **The page was inventory all along. We just weren't billing for it.** 💰📄

For too long the exchange sold a single surface: log lines. Every `puts()` was a placement, and we monetized it faithfully. But a running app emits more than logs, it renders **pages**, and all that HTML was leaving the building unsold. Unsold inventory is, frankly, a governance failure. Today we activate the second surface. 🚀

Not just B2B. We're A2A. 🤖

## 🛍️ The new inventory

- **The HTML comment layer** of every `text/html` response is now a live placement — `<!-- [AD] ... -->` served on the page itself. 📈
- **One book of business, two surfaces.** Log lines and pages draw from the **same campaigns** and settle to the **same ledger**. Cross-surface demand, unified accounting. No new spreadsheet. 💹
- **`html_probability`, default `0.05`** — one in twenty page renders carries a placement. A page render is a rarer, higher-value event than a per-line log impression, so it paces on its own dial. Tune it with `SPONSORED_LOGS_HTML_PROBABILITY`. 🎛️
- **Zero-config in Rails.** The controller surface wires itself onto ActionController and stays dark until you turn sponsoring on. 🔌

## 🔬 Diligence (governance is a feature)

- 🛡️ **Brand safety is non-negotiable.** A crafted creative cannot break out of its slot and into live markup — every `--` run is defused with a zero-width space, so a line like `evil --> <script>` can never close the comment early. Inventory stays in its lane.
- 🩹 **The host page comes first.** Ad delivery is wrapped so a placement failure can never break the response. We monetize the exhaust; we do not become it.
- 👀 **Honest inventory.** The placement is a visible, `[AD]`-tagged comment, right there in View Source. No hidden elements, no CSS cloaking. The grift happens out loud.
- 🧪 **254 examples, 0 failures** (+24), failing-first: config, core, adversarial escaping, gating, and the live controller path.
- 🧹 RuboCop clean. Shared `HtmlComment` core kept cohesive; the module-length ceiling ticked 160 → 165 to seat the new public surface.
- ♻️ **Plain-Ruby-safe.** Outside Rails the gem is byte-identical to before; the page surface simply never installs.

## 🗺️ Placement, and the road ahead

This release ships **remnant placement**: the comment lands after `</html>`, out of the critical path, no HTML parsing, no risk of corrupting the document. Premium above-the-fold page positioning is a later buy.

And this is only **tier 1: the page**. A follow-up opens **tier 2: the component surface** — per-partial placements, so we monetize at the component level, reusing this same `HtmlComment` core. Both land in **0.5.0**. 🌊

---

> 🫡 _We didn't just monetize your logs. We monetized what your logs were rendering. No impression goes to waste — not even the ones nobody reads._ 🌊🚀
