### PR TITLE
Open the component as a per-partial ad surface

### DIFF
--- a/lib/sponsored_logs/configuration.rb
+++ b/lib/sponsored_logs/configuration.rb
@@ -3,7 +3,7 @@
 module SponsoredLogs
   class Configuration
     attr_accessor :probability, :html_probability, :periodic, :interval, :output, :ad_prefix, :ads, :selection, :store,
-                  :report_page, :ascii_only, :house_ads
+                  :report_page, :ascii_only, :house_ads, :partial_ads
     attr_reader :color
 
     # Gilding modes for the [AD] prefix. :auto gilds only on a NO_COLOR-clear
@@ -15,7 +15,7 @@ module SponsoredLogs
     # separately because they interact (ads wins; ads_file loads into ads).
     #
     DIRECT_KEYS = %i[probability html_probability periodic interval output ad_prefix selection store report_page
-                     ascii_only house_ads color].freeze
+                     ascii_only house_ads partial_ads color].freeze
     KNOWN_KEYS = (DIRECT_KEYS + %i[ads ads_file]).freeze
 
     def initialize
@@ -31,6 +31,7 @@ module SponsoredLogs
       @report_page = false
       @ascii_only = false
       @house_ads = true
+      @partial_ads = false
       @color = :auto
     end
 

--- a/lib/sponsored_logs/env.rb
+++ b/lib/sponsored_logs/env.rb
@@ -22,6 +22,7 @@ module SponsoredLogs
       "SPONSORED_LOGS_SELECTION" => [:selection, :to_sym.to_proc],
       "SPONSORED_LOGS_ASCII_ONLY" => [:ascii_only, ->(v) { truthy?(v) }],
       "SPONSORED_LOGS_HOUSE_ADS" => [:house_ads, ->(v) { truthy?(v) }],
+      "SPONSORED_LOGS_PARTIAL_ADS" => [:partial_ads, ->(v) { truthy?(v) }],
       "SPONSORED_LOGS_COLOR" => [:color, ->(v) { color_mode(v) }]
     }.freeze
 

--- a/lib/sponsored_logs/html_comment.rb
+++ b/lib/sponsored_logs/html_comment.rb
@@ -29,6 +29,49 @@ module SponsoredLogs
       "<!-- #{escape(body)} -->"
     end
 
+    # Minimum stripped length a fragment must clear before it is worth (and safe)
+    # decorating. Tiny fragments are usually icons, inline glyphs, or partials
+    # whose whole job is one attribute or word, where a trailing comment is noise
+    # at best and risky at worst.
+    #
+    MIN_INJECTABLE_LENGTH = 10
+
+    # A closing element tag such as "</div>" or "</my-widget>". Its presence is
+    # our proxy for "this rendered string is real HTML element markup" rather
+    # than attribute soup, plain text, or a data blob.
+    #
+    CLOSING_TAG = %r{</[a-zA-Z][\w:-]*>}
+
+    # Conservative gate for the per-partial hook: return true only when a rendered
+    # partial string looks like ordinary HTML element markup into which an inert
+    # "<!-- [AD] ... -->" comment can be appended harmlessly. We deliberately err
+    # toward false: a skipped placement costs nothing, but a comment dropped into
+    # a script body, a JSON response, or an SVG document can corrupt the payload.
+    # We inspect the OUTPUT string only (never template source), so the check is
+    # identical for ERB, HAML, and Slim.
+    #
+    # A fragment is injectable only when ALL of these hold:
+    # - it is non-blank and clears MIN_INJECTABLE_LENGTH (skip trivial fragments),
+    # - it contains at least one closing element tag (skip text / void-only soup),
+    # - it does not contain "<script" (an HTML comment inside JS is a syntax hazard
+    #   and inside a <script> body is not even a comment),
+    # - it does not contain "<svg" (SVG/XML documents have their own comment rules
+    #   and are not log-style HTML; blanket-skip them rather than reason per-node),
+    # - it does not begin with "{" or "[" after stripping (skip JSON-ish blobs;
+    #   a partial can render a data structure, and "-->" is not JSON).
+    #
+    def injectable?(str)
+      return false if str.nil?
+
+      stripped = str.to_s.strip
+      return false if stripped.length < MIN_INJECTABLE_LENGTH
+      return false if stripped.start_with?("{", "[")
+      return false if stripped.match?(/<script/i)
+      return false if stripped.match?(/<svg/i)
+
+      stripped.match?(CLOSING_TAG)
+    end
+
     # Neutralize the HTML comment delimiter so crafted ad copy cannot close the
     # comment early and break out into live markup (comment-injection). Any "--"
     # run is defused by inserting a zero-width space between the hyphens, which

--- a/lib/sponsored_logs/partial_patch.rb
+++ b/lib/sponsored_logs/partial_patch.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require_relative "html_comment"
+
+module SponsoredLogs
+  # Tier 2 of HTML-comment ads: append a host-read [AD] comment after a rendered
+  # partial, turning partial-heavy pages into component-level ad inventory. We
+  # prepend onto ActionView::Renderer#render, the single entry point whose return
+  # value is the final rendered STRING, and act only when options carries
+  # :partial so full template renders (the page tier's job) are left alone.
+  # Hooking the output string (never the template source) makes this
+  # engine-agnostic for free: ERB, HAML, and Slim all compile down to the same
+  # rendered string.
+  #
+  # Higher risk than the page tier, so it is doubly gated at runtime: the
+  # partial_ads flag is off by default AND SponsoredLogs must be active AND the
+  # html_probability roll must pass (all inside decorate via maybe_html_comment).
+  # The prepend itself is therefore inert until explicitly enabled, exactly like
+  # the controller patch, so installing it unconditionally is safe.
+  #
+  module PartialPatch
+    module RenderPatch
+      def render(context, options)
+        rendered = super
+        return rendered unless options.is_a?(Hash) && options.key?(:partial)
+
+        SponsoredLogs::PartialPatch.decorate(rendered)
+      end
+    end
+
+    # Given the rendered string of one partial, optionally append an [AD] comment
+    # and return the (possibly augmented) string. Every gate that could suppress
+    # a placement lives here so the prepend stays a thin pass-through:
+    # - partial_ads must be enabled (opt-in; off by default),
+    # - maybe_html_comment enforces active? + the html_probability roll,
+    # - injectable? confirms the string is ordinary HTML element markup and not a
+    #   script body, JSON blob, SVG document, or trivial fragment.
+    # The original string is always returned untouched when any gate fails, and a
+    # rescue guarantees an ad failure can never break the host render.
+    #
+    def self.decorate(rendered)
+      return rendered unless SponsoredLogs.configuration.partial_ads
+      return rendered unless HtmlComment.injectable?(rendered.to_s)
+
+      comment = SponsoredLogs.maybe_html_comment
+      return rendered if comment.nil?
+
+      "#{rendered}#{comment}"
+    rescue StandardError
+      # Ad delivery must never break the host render; swallow and return as-is.
+      #
+      rendered
+    end
+
+    def self.install!
+      return if @installed
+      return unless defined?(ActionView::Renderer)
+
+      ActionView::Renderer.prepend(RenderPatch)
+      @installed = true
+    end
+
+    def self.installed?
+      @installed == true
+    end
+  end
+end

--- a/lib/sponsored_logs/railtie.rb
+++ b/lib/sponsored_logs/railtie.rb
@@ -3,6 +3,7 @@
 require "rails/railtie"
 
 require_relative "controller_patch"
+require_relative "partial_patch"
 
 module SponsoredLogs
   class Railtie < Rails::Railtie
@@ -25,6 +26,18 @@ module SponsoredLogs
     initializer "sponsored_logs.controller_patch" do
       ActiveSupport.on_load(:action_controller) do
         SponsoredLogs::ControllerPatch.install!
+      end
+    end
+
+    # Wire the per-partial render patch onto ActionView once it has loaded. Same
+    # philosophy as the controller patch: the prepend is inert until partial_ads
+    # is enabled AND sponsoring is active (runtime gating lives in
+    # PartialPatch.decorate), so installing it here is safe even when the host
+    # never opts into partial ads.
+    #
+    initializer "sponsored_logs.partial_patch" do
+      ActiveSupport.on_load(:action_view) do
+        SponsoredLogs::PartialPatch.install!
       end
     end
   end

--- a/spec/env_spec.rb
+++ b/spec/env_spec.rb
@@ -27,7 +27,8 @@ RSpec.describe SponsoredLogs::Env do
         "SPONSORED_LOGS_INTERVAL" => "15",
         "SPONSORED_LOGS_PERIODIC" => "true",
         "SPONSORED_LOGS_PREFIX" => "SPONSORED:",
-        "SPONSORED_LOGS_ADS_FILE" => "/tmp/ads.json"
+        "SPONSORED_LOGS_ADS_FILE" => "/tmp/ads.json",
+        "SPONSORED_LOGS_PARTIAL_ADS" => "true"
       }
 
       expect(described_class.options(env)).to eq(
@@ -36,8 +37,16 @@ RSpec.describe SponsoredLogs::Env do
         interval: 15.0,
         periodic: true,
         ad_prefix: "SPONSORED:",
-        ads_file: "/tmp/ads.json"
+        ads_file: "/tmp/ads.json",
+        partial_ads: true
       )
+    end
+
+    it "coerces SPONSORED_LOGS_PARTIAL_ADS truthily", :aggregate_failures do
+      expect(described_class.options("SPONSORED_LOGS_PARTIAL_ADS" => "1")).to eq(partial_ads: true)
+      expect(described_class.options("SPONSORED_LOGS_PARTIAL_ADS" => "on")).to eq(partial_ads: true)
+      expect(described_class.options("SPONSORED_LOGS_PARTIAL_ADS" => "0")).to eq(partial_ads: false)
+      expect(described_class.options("SPONSORED_LOGS_PARTIAL_ADS" => "nope")).to eq(partial_ads: false)
     end
   end
 end

--- a/spec/html_comment_spec.rb
+++ b/spec/html_comment_spec.rb
@@ -29,6 +29,25 @@ RSpec.describe SponsoredLogs do
     end
   end
 
+  describe "partial_ads configuration" do
+    it "defaults to false" do
+      expect(described_class.configuration.partial_ads).to be(false)
+    end
+
+    it "is applied via sponsor!/assign" do
+      described_class.sponsor!(partial_ads: true)
+
+      expect(described_class.configuration.partial_ads).to be(true)
+    end
+
+    it "accepts string keys through assign" do
+      config = SponsoredLogs::Configuration.new
+      config.assign({ "partial_ads" => true }, warn_to: StringIO.new)
+
+      expect(config.partial_ads).to be(true)
+    end
+  end
+
   describe ".render_html_comment" do
     it "wraps the picked ad text as an HTML comment", :aggregate_failures do
       described_class.sponsor!(ads: [{ text: "Buy widgets now", weight: 1 }])
@@ -109,6 +128,45 @@ RSpec.describe SponsoredLogs do
   end
 
   describe SponsoredLogs::HtmlComment do
+    describe ".injectable?" do
+      it "accepts a fragment with a real closing element tag", :aggregate_failures do
+        expect(described_class.injectable?("<div>hello world here</div>")).to be(true)
+        expect(described_class.injectable?("<ul><li>one</li><li>two</li></ul>")).to be(true)
+        expect(described_class.injectable?("<section><p>Body copy goes here.</p></section>")).to be(true)
+      end
+
+      it "skips a script fragment", :aggregate_failures do
+        expect(described_class.injectable?("<script>var x = 1;</script>")).to be(false)
+        expect(described_class.injectable?("<SCRIPT>alert(1)</SCRIPT>")).to be(false)
+        expect(described_class.injectable?("<div><script>var y=2;</script></div>")).to be(false)
+      end
+
+      it "skips a JSON-looking fragment", :aggregate_failures do
+        expect(described_class.injectable?('{ "a": 1, "b": 2 }')).to be(false)
+        expect(described_class.injectable?('[ { "a": 1 }, { "b": 2 } ]')).to be(false)
+      end
+
+      it "skips a bare text or whitespace fragment", :aggregate_failures do
+        expect(described_class.injectable?("just some plain text with no tags")).to be(false)
+        expect(described_class.injectable?("     \n\t   ")).to be(false)
+        expect(described_class.injectable?("")).to be(false)
+        expect(described_class.injectable?(nil)).to be(false)
+      end
+
+      it "skips an SVG-only fragment" do
+        expect(described_class.injectable?("<svg><circle r='5'></circle></svg>")).to be(false)
+      end
+
+      it "skips an attribute-or-void-only fragment with no closing tag", :aggregate_failures do
+        expect(described_class.injectable?('<input type="text" name="q" />')).to be(false)
+        expect(described_class.injectable?("<br><hr>")).to be(false)
+      end
+
+      it "skips a fragment below the trivial length floor" do
+        expect(described_class.injectable?("<i>x</i>")).to be(false)
+      end
+    end
+
     describe ".escape" do
       it "leaves copy without hyphen runs untouched" do
         expect(described_class.escape("plain copy")).to eq("plain copy")

--- a/spec/partial_patch_spec.rb
+++ b/spec/partial_patch_spec.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+require "tmpdir"
+
+require "action_view"
+
+require "sponsored_logs/partial_patch"
+
+# Like controller_patch_spec, we avoid booting a Rails::Application (engine_spec
+# owns the single permitted initialize!). Two layers are exercised here:
+#
+# - decorate: the pure seam the prepend calls, driven with plain strings so the
+#   gating (partial_ads + active? + probability + injectable?) is unit-testable.
+# - the real prepend: a genuine ActionView::Base rendering a real ERB partial
+#   from a temp dir, so we prove Renderer#render_partial actually routes through
+#   our patch and returns the augmented string, engine boot not required.
+#
+RSpec.describe SponsoredLogs::PartialPatch do
+  before(:all) do
+    SponsoredLogs::PartialPatch.install!
+  end
+
+  describe ".decorate" do
+    it "appends a comment to HTML markup when enabled, active, and rolled in", :aggregate_failures do
+      SponsoredLogs.sponsor!(partial_ads: true, html_probability: 1.0, ads: [{ text: "Partial ad", weight: 1 }])
+
+      result = described_class.decorate("<div>Component body content</div>")
+
+      expect(result).to include("<div>Component body content</div>")
+      expect(result).to include("<!-- [AD] Partial ad -->")
+      # The comment trails the rendered markup.
+      #
+      expect(result).to match(%r{</div>.*<!-- \[AD\] Partial ad -->}m)
+    end
+
+    it "returns the string untouched when partial_ads is off" do
+      SponsoredLogs.sponsor!(partial_ads: false, html_probability: 1.0, ads: [{ text: "Partial ad", weight: 1 }])
+
+      result = described_class.decorate("<div>Component body content</div>")
+
+      expect(result).to eq("<div>Component body content</div>")
+    end
+
+    it "returns the string untouched when sponsoring is inactive" do
+      SponsoredLogs.unsponsor!
+      SponsoredLogs.configuration.partial_ads = true
+      SponsoredLogs.configuration.html_probability = 1.0
+
+      result = described_class.decorate("<div>Component body content</div>")
+
+      expect(result).to eq("<div>Component body content</div>")
+    end
+
+    it "respects an html_probability of zero" do
+      SponsoredLogs.sponsor!(partial_ads: true, html_probability: 0.0, ads: [{ text: "Partial ad", weight: 1 }])
+
+      result = described_class.decorate("<div>Component body content</div>")
+
+      expect(result).not_to include("[AD]")
+    end
+
+    it "skips fragments the injectable guard rejects", :aggregate_failures do
+      SponsoredLogs.sponsor!(partial_ads: true, html_probability: 1.0, ads: [{ text: "Partial ad", weight: 1 }])
+
+      expect(described_class.decorate("<script>var x = 1;</script>")).to eq("<script>var x = 1;</script>")
+      expect(described_class.decorate('{ "a": 1, "b": 2 }')).to eq('{ "a": 1, "b": 2 }')
+      expect(described_class.decorate("plain text, no markup at all")).to eq("plain text, no markup at all")
+      expect(described_class.decorate("<svg><circle r='5'></circle></svg>")).to eq("<svg><circle r='5'></circle></svg>")
+    end
+
+    it "records the impression to the shared ledger", :aggregate_failures do
+      SponsoredLogs.sponsor!(partial_ads: true, html_probability: 1.0, ads: [{ text: "Shared", weight: 1, cpm: 10.0 }])
+
+      expect { described_class.decorate("<div>Component body content</div>") }
+        .to change { SponsoredLogs.ledger.total_impressions }.by(1)
+    end
+
+    it "draws from the same campaigns as logs and pages" do
+      SponsoredLogs.sponsor!(partial_ads: true, html_probability: 1.0, ads: [{ text: "OnlyCampaign", weight: 1 }])
+
+      result = described_class.decorate("<div>Component body content</div>")
+
+      expect(result).to include("OnlyCampaign")
+    end
+
+    it "never lets an ad failure break the host string" do
+      SponsoredLogs.sponsor!(partial_ads: true, html_probability: 1.0, ads: [{ text: "Boom", weight: 1 }])
+      allow(SponsoredLogs).to receive(:maybe_html_comment).and_raise("kaboom")
+
+      result = described_class.decorate("<div>Component body content</div>")
+
+      expect(result).to eq("<div>Component body content</div>")
+    end
+  end
+
+  describe "install!/installed?" do
+    it "is idempotent and reports installed", :aggregate_failures do
+      described_class.install!
+      described_class.install!
+
+      expect(described_class.installed?).to be(true)
+    end
+  end
+
+  describe "the real prepended render_partial path" do
+    around do |example|
+      Dir.mktmpdir do |dir|
+        @template_dir = dir
+        example.run
+      end
+    end
+
+    def render_partial(name)
+      lookup = ActionView::LookupContext.new([@template_dir])
+      view = ActionView::Base.with_empty_template_cache.new(lookup, {}, nil)
+      view.render(partial: name)
+    end
+
+    it "augments a real rendered HTML partial when enabled", :aggregate_failures do
+      File.write(File.join(@template_dir, "_widget.html.erb"), "<div>hello from the widget partial</div>")
+      SponsoredLogs.sponsor!(partial_ads: true, html_probability: 1.0, ads: [{ text: "Real partial ad", weight: 1 }])
+
+      out = render_partial("widget")
+
+      expect(out).to include("<div>hello from the widget partial</div>")
+      expect(out).to include("<!-- [AD] Real partial ad -->")
+    end
+
+    it "leaves a real rendered partial untouched when partial_ads is off" do
+      File.write(File.join(@template_dir, "_widget.html.erb"), "<div>hello from the widget partial</div>")
+      SponsoredLogs.sponsor!(partial_ads: false, html_probability: 1.0, ads: [{ text: "Real partial ad", weight: 1 }])
+
+      out = render_partial("widget")
+
+      expect(out).not_to include("[AD]")
+    end
+
+    it "leaves a real rendered non-HTML partial untouched" do
+      File.write(File.join(@template_dir, "_data.html.erb"), '{ "count": 42, "ok": true }')
+      SponsoredLogs.sponsor!(partial_ads: true, html_probability: 1.0, ads: [{ text: "Real partial ad", weight: 1 }])
+
+      out = render_partial("data")
+
+      expect(out).not_to include("[AD]")
+    end
+  end
+end


### PR DESCRIPTION
> 🧩💰 **A page is not one placement. It is many.** 💰🧩

The page tier sold the whole HTML response. But every app renders **partials**, and a partial is a component, and a component is inventory the exchange was not yet billing for. This opens **tier 2: the per-partial surface**, so a partial-heavy page fills at the component level. We monetize the exhaust, now down to the component. 🚀

One book of business, three surfaces: logs, pages, and now components. Not just B2B. We're A2A. 🤖

## 🛍️ The new inventory

- **Every partial is a placement.** A rendered partial now carries an optional `<!-- [AD] ... -->` comment, so component-dense pages become dense inventory. 📈
- **Same campaigns, same ledger.** Placements route through the tier-1 `HtmlComment` core, so partials draw from the same demand and settle to the same book as logs and pages. No new spreadsheet. 💹
- **Opt-in, off by default.** A new `partial_ads` flag (and `SPONSORED_LOGS_PARTIAL_ADS`) gates the whole surface. Tier 2 is a bolder buy than the page, so adopters activate it deliberately. The page tier keeps running as-is. 🎛️
- **Engine-agnostic by construction.** The hook reads the rendered output string, never the template, so ERB, HAML, and Slim are billed identically. 🔌

## 🔬 Diligence (governance is a feature)

- 🛡️ **Inventory stays in its lane.** A conservative `injectable?` guard decorates only output that reads as ordinary HTML element markup, and skips script bodies, JSON blobs, SVG documents, and trivial fragments. A placement dropped into the wrong context is not inventory, it is a defect. When in doubt, we skip.
- 🎯 **No double-billing the page.** The patch prepends onto `ActionView::Renderer#render` but acts only on `:partial` renders, so it never collides with the tier-1 page placement.
- 🩹 **The host render comes first.** Delivery is rescue-wrapped: an ad failure can never break a partial.
- 🧪 **277 examples, 0 failures** (+23), failing-first: the guard's full adversarial set (`<div>` in, `<script>`/JSON/SVG/void/text/tiny out), opt-in gating, shared-ledger reuse, and the real prepended ActionView path.
- 🧹 RuboCop clean. Selection, recording, and `-->` hardening are reused verbatim from tier 1, not reimplemented.
- ♻️ **Plain-Ruby-safe.** Outside Rails the surface simply never installs.

## 🗺️ The surface map

Three tiers now stand up on one core: **the line** (logs), **the page** (tier 1, shipped in #23), and **the component** (tier 2, this PR). All three land together in **0.5.0**. 🌊

---

> 🫡 _We didn't just monetize your logs, or even your pages. We monetized the components they were assembled from. No impression goes to waste, and no partial ships unsold._ 🌊🚀
